### PR TITLE
Release 2.1.0 — modern complex-valued architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,85 @@ All notable changes to `complextorch` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+A large modern-architecture expansion: positional encodings, interference-aware
+attention, state-space models, unitary RNNs, learnable signal front-ends,
+complex KANs, and Steinmetz/analytic networks.
+
+### Added
+
+- **Complex positional encodings** (`complextorch.nn`): `RotaryEmbedding`
+  (relative RoPE — rotates per-head queries/keys by complex phasors so the
+  Hermitian attention score depends only on relative position),
+  `SinusoidalPositionalEncoding` (fixed absolute), and `CoPE` (lightweight
+  learnable absolute). `MultiheadAttention` gains an optional `rotary=`
+  argument and `models.ViT` a `pos_encoding=` selector
+  (`"learned"` / `"sinusoidal"` / `"rotary"`). The native transformer applies
+  no positional encoding on its own, so these fill a real gap. See
+  [Complex positional encodings](concepts/positional-encoding.md).
+- **Holographic (interference-aware) attention**: `HolographicAttention`
+  gates attention logits by the query/key phase discrepancy and performs a
+  coherent (phase-rotated) superposition of the values; selectable inside
+  `MultiheadAttention` via `attention="holographic"`. Adds the companion
+  `HolographicReconstructionLoss` and `phase_smoothness` regularizer
+  (anti-phase-collapse safeguards). After Holographic Transformers
+  ([arXiv:2509.19331](https://arxiv.org/abs/2509.19331)). See
+  [Holographic attention](concepts/holographic-attention.md).
+- **Complex diagonal state-space models**: `S4D` (HiPPO-Lin-initialised
+  diagonal-complex SSM with an FFT long-convolution and an exact recurrent
+  rollout), `DSS` (normalised-kernel variant), `S4DBlock` (residual block), and
+  `MambaBlock` (selective, input-dependent S6 scan). Linear-time long-sequence
+  modelling for the 1-D signals this package targets. After S4D
+  ([arXiv:2206.11893](https://arxiv.org/abs/2206.11893)), DSS
+  ([arXiv:2203.14343](https://arxiv.org/abs/2203.14343)), and Mamba
+  ([arXiv:2312.00752](https://arxiv.org/abs/2312.00752)). See
+  [Complex state-space models](concepts/state-space-models.md).
+- **Unitary complex RNN**: `UnitaryRNN` / `UnitaryRNNCell` — a norm-preserving
+  recurrence whose hidden-to-hidden matrix is the Cayley transform of a
+  learnable skew-Hermitian generator (eigenvalues on the unit circle), with an
+  `AdaptiveModReLU` nonlinearity and `trabelsi_independent_` semi-unitary init.
+  The classic complex-domain fix for vanishing/exploding gradients on long
+  sequences; complements the existing `GRU` / `LSTM`. After uRNN
+  ([arXiv:1511.06464](https://arxiv.org/abs/1511.06464)) and the Cayley/scoRNN
+  line ([arXiv:1707.09520](https://arxiv.org/abs/1707.09520)). See
+  [Unitary complex RNNs](concepts/unitary-rnn.md).
+- **Learnable complex time-frequency front-ends**: `STFT` / `InverseSTFT`
+  (short-time Fourier transform with a learnable analysis/synthesis window and
+  exact window-squared overlap-add reconstruction when the synthesis window is
+  tied to the analysis window) and `ComplexGaborConv1d` / `MorletConv1d`
+  (learnable complex Gabor/Morlet filterbanks — a complex, wavelet-style
+  analogue of SincNet). Differentiable signal front-ends that emit native
+  complex time-frequency representations. See
+  [Learnable time-frequency front-ends](concepts/time-frequency-frontends.md).
+- **Complex-Valued KAN**: `complextorch.nn.CVKANLayer` (a Kolmogorov-Arnold edge
+  layer whose univariate functions are a learnable Gaussian radial-basis
+  expansion over the complex plane, plus a complex linear base) and the
+  `complextorch.models.CVKAN` stack. After CVKAN
+  ([arXiv:2502.02417](https://arxiv.org/abs/2502.02417)). See
+  [Complex-Valued KANs](concepts/kan.md).
+- **Steinmetz & Analytic networks**: `complextorch.models.SteinmetzNetwork`
+  (parallel real-valued subnetworks with coupled outputs) and
+  `complextorch.models.AnalyticNeuralNetwork` (Steinmetz + an analytic-signal
+  consistency penalty that tightens the generalisation bound). Adds the reusable
+  `complextorch.nn.AnalyticSignalLoss` consistency penalty. After Steinmetz
+  Neural Networks ([arXiv:2409.10075](https://arxiv.org/abs/2409.10075)). See
+  [Steinmetz & Analytic networks](concepts/steinmetz.md).
+- **Signal utilities**: `complextorch.signal.analytic_signal` and
+  `complextorch.signal.hilbert` — a differentiable torch port of
+  `scipy.signal.hilbert` (analytic signal / Hilbert transform), reused by the
+  analytic-signal consistency penalty.
+
+### Fixed
+
+- `wFMConvStrict2d` now computes the phase mean as the **circular** (Fréchet)
+  mean on `SO(2)` — averaging the unit phase vectors and recovering the angle
+  via `atan2` — instead of an arithmetic mean of the raw principal-value angles.
+  The previous behaviour (a faithful port of RotLieNet's `ComplexConv2Deffangle`)
+  was wrong across the ±π branch cut; the circular mean is the correct manifold
+  Fréchet mean and makes the layer exactly U(1)-equivariant for any input phase
+  distribution.
+
 ## [2.0.1]
 
 ### Fixed

--- a/complextorch/__init__.py
+++ b/complextorch/__init__.py
@@ -10,7 +10,7 @@ For more information see: https://pypi.org/project/complextorch or https://githu
 
 __author__ = "Josiah W. Smith"
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 
 __all__ = ["datasets", "models", "nn", "signal", "transforms"]
 

--- a/complextorch/models/__init__.py
+++ b/complextorch/models/__init__.py
@@ -6,12 +6,17 @@ Reference architectures composed from the primitives in :mod:`complextorch.nn`.
 """
 
 from complextorch.models.cds import CDSMSTAR, CDSEquivariant, CDSInvariant
+from complextorch.models.kan import CVKAN
+from complextorch.models.steinmetz import AnalyticNeuralNetwork, SteinmetzNetwork
 from complextorch.models.vit import ViT, ViTLayer, vit_b, vit_h, vit_l, vit_s, vit_t
 
 __all__ = [
     "CDSMSTAR",
+    "CVKAN",
+    "AnalyticNeuralNetwork",
     "CDSEquivariant",
     "CDSInvariant",
+    "SteinmetzNetwork",
     "ViT",
     "ViTLayer",
     "vit_b",

--- a/complextorch/models/kan.py
+++ b/complextorch/models/kan.py
@@ -1,0 +1,46 @@
+r"""
+Complex-Valued Kolmogorov-Arnold Network (CVKAN)
+================================================
+
+A KAN-style stack of :class:`complextorch.nn.CVKANLayer` edge-function layers.
+See https://arxiv.org/abs/2502.02417.
+"""
+
+import itertools
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.kan import CVKANLayer
+
+__all__ = ["CVKAN"]
+
+
+class CVKAN(nn.Module):
+    r"""
+    Complex-Valued Kolmogorov-Arnold Network.
+
+    Stacks :class:`complextorch.nn.CVKANLayer` layers according to
+    ``layer_sizes`` (e.g. ``[in, hidden, out]``). Operates on complex tensors of
+    shape ``(..., layer_sizes[0])`` and returns ``(..., layer_sizes[-1])``.
+
+    Args:
+        layer_sizes: feature sizes from input to output (length >= 2).
+        num_grid: grid resolution per axis for each :class:`CVKANLayer`.
+    """
+
+    def __init__(self, layer_sizes: list[int], num_grid: int = 8) -> None:
+        super().__init__()
+        if len(layer_sizes) < 2:
+            raise ValueError("layer_sizes must have at least two entries (in, out)")
+        self.layers = nn.ModuleList(
+            [
+                CVKANLayer(a, b, num_grid=num_grid)
+                for a, b in itertools.pairwise(layer_sizes)
+            ]
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            input = layer(input)
+        return input

--- a/complextorch/models/steinmetz.py
+++ b/complextorch/models/steinmetz.py
@@ -1,0 +1,126 @@
+r"""
+Steinmetz & Analytic Neural Networks
+====================================
+
+Architectures that process complex-valued data with **parallel real-valued
+subnetworks** whose outputs are coupled into a complex latent (Steinmetz), with
+an optional **analytic-signal consistency penalty** (Analytic Neural Network)
+that encourages a deterministic, orthogonal relationship between the real and
+imaginary channels and provably tightens the generalisation gap.
+
+Reference:
+
+    - **Venkatasubramanian, Pezeshki, Tarokh. Steinmetz Neural Networks for
+      Complex-Valued Data.** AISTATS 2025. https://arxiv.org/abs/2409.10075
+"""
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.loss import AnalyticSignalLoss
+
+__all__ = ["AnalyticNeuralNetwork", "SteinmetzNetwork"]
+
+
+class _RealMLP(nn.Module):
+    """Plain real-valued MLP (Linear -> ReLU stack)."""
+
+    def __init__(
+        self, in_features: int, hidden_features: int, out_features: int, depth: int
+    ) -> None:
+        super().__init__()
+        layers: list[nn.Module] = []
+        size = in_features
+        for _ in range(max(depth - 1, 0)):
+            layers += [nn.Linear(size, hidden_features), nn.ReLU()]
+            size = hidden_features
+        layers.append(nn.Linear(size, out_features))
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class SteinmetzNetwork(nn.Module):
+    r"""
+    Steinmetz Network
+    -----------------
+
+    Two **parallel real-valued** subnetworks consume the stacked
+    ``[Re(z), Im(z)]`` features and produce the real and imaginary parts of a
+    complex latent, which are coupled with :func:`torch.complex`:
+
+    .. math::
+
+        u = f_\Re([\Re z, \Im z]), \quad
+        v = f_\Im([\Re z, \Im z]), \quad
+        \hat{z} = u + j v.
+
+    Args:
+        in_features: number of complex input features.
+        hidden_features: width of the real subnetworks.
+        out_features: number of complex output features.
+        depth: number of linear layers in each subnetwork.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        out_features: int,
+        depth: int = 2,
+    ) -> None:
+        super().__init__()
+        self.real_branch = _RealMLP(
+            2 * in_features, hidden_features, out_features, depth
+        )
+        self.imag_branch = _RealMLP(
+            2 * in_features, hidden_features, out_features, depth
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Map a complex input to a complex output via the coupled real branches.
+
+        Args:
+            input (torch.Tensor): complex ``(..., in_features)`` tensor.
+
+        Returns:
+            torch.Tensor: complex ``(..., out_features)`` tensor.
+        """
+        feat = torch.cat([input.real, input.imag], dim=-1)
+        return torch.complex(self.real_branch(feat), self.imag_branch(feat))
+
+
+class AnalyticNeuralNetwork(SteinmetzNetwork):
+    r"""
+    Analytic Neural Network
+    -----------------------
+
+    A :class:`SteinmetzNetwork` paired with the analytic-signal consistency
+    penalty (:class:`complextorch.nn.AnalyticSignalLoss`). Add
+    :meth:`consistency_loss` of the network output to the task loss during
+    training to push the latent towards a true analytic signal
+    (:math:`\Im(\hat z) = \mathcal{H}\{\Re(\hat z)\}`), which the paper shows
+    lowers the generalisation-gap bound relative to a generic Steinmetz network.
+
+    Args:
+        in_features, hidden_features, out_features, depth: see
+            :class:`SteinmetzNetwork`.
+        consistency_dim: signal dimension for the Hilbert transform in the
+            consistency penalty.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        out_features: int,
+        depth: int = 2,
+        consistency_dim: int = -1,
+    ) -> None:
+        super().__init__(in_features, hidden_features, out_features, depth)
+        self.consistency = AnalyticSignalLoss(dim=consistency_dim)
+
+    def consistency_loss(self, z: torch.Tensor) -> torch.Tensor:
+        """Analytic-signal consistency penalty of a (network output) latent."""
+        return self.consistency(z)

--- a/complextorch/models/vit.py
+++ b/complextorch/models/vit.py
@@ -19,6 +19,10 @@ from complextorch.nn.modules.conv import Conv2d
 from complextorch.nn.modules.dropout import Dropout
 from complextorch.nn.modules.layernorm import LayerNorm
 from complextorch.nn.modules.linear import Linear
+from complextorch.nn.modules.position import (
+    RotaryEmbedding,
+    SinusoidalPositionalEncoding,
+)
 
 __all__ = ["ViT", "ViTLayer", "vit_b", "vit_h", "vit_l", "vit_s", "vit_t"]
 
@@ -55,13 +59,20 @@ class ViTLayer(nn.Module):
         dropout: float = 0.0,
         layer_norm_eps: float = 1e-5,
         softmax_on: str = "complex",
+        rotary: RotaryEmbedding | None = None,
     ) -> None:
         super().__init__()
         if dim % nhead != 0:
             raise ValueError(f"dim ({dim}) must be divisible by nhead ({nhead})")
         d_head = dim // nhead
         self.attn = MultiheadAttention(
-            nhead, dim, d_head, d_head, dropout=dropout, softmax_on=softmax_on
+            nhead,
+            dim,
+            d_head,
+            d_head,
+            dropout=dropout,
+            softmax_on=softmax_on,
+            rotary=rotary,
         )
         self.ffn = _ViTFFN(dim, mlp_dim, dropout, layer_norm_eps)
 
@@ -85,6 +96,16 @@ class ViT(nn.Module):
         mlp_dim: width of the FFN.
         dropout: dropout probability.
         softmax_on: ``'complex'`` or ``'real'``; controls attention softmax.
+        pos_encoding: positional-encoding scheme:
+
+            - ``'learned'`` (default): a learned complex ``pos_embed`` parameter
+              added to the token + patch embeddings (original behaviour).
+            - ``'sinusoidal'``: a fixed complex
+              :class:`~complextorch.nn.SinusoidalPositionalEncoding` added to the
+              embeddings.
+            - ``'rotary'``: relative :class:`~complextorch.nn.RotaryEmbedding`
+              applied to the per-head query/key tensors inside attention; no
+              additive position embedding is used.
 
     Note: the classification head returns a complex ``(B, num_classes)``
     tensor. Most downstream losses take ``|·|`` first.
@@ -103,31 +124,52 @@ class ViT(nn.Module):
         dropout: float = 0.0,
         layer_norm_eps: float = 1e-5,
         softmax_on: str = "complex",
+        pos_encoding: str = "learned",
     ) -> None:
         super().__init__()
         if image_size % patch_size != 0:
             raise ValueError(
                 f"image_size ({image_size}) must be divisible by patch_size ({patch_size})"
             )
+        if pos_encoding not in ("learned", "sinusoidal", "rotary"):
+            raise ValueError(
+                "pos_encoding must be 'learned', 'sinusoidal' or 'rotary'; "
+                f"got {pos_encoding!r}"
+            )
+        if dim % heads != 0:
+            raise ValueError(f"dim ({dim}) must be divisible by heads ({heads})")
         num_patches = (image_size // patch_size) ** 2
+        self.pos_encoding = pos_encoding
         self.patch_embed = Conv2d(
             in_channels, dim, kernel_size=patch_size, stride=patch_size, bias=True
         )
-        # Class token and positional embedding are complex parameters.
+        # Class token is a complex parameter.
         self.cls_token = nn.Parameter(torch.zeros(1, 1, dim, dtype=torch.cfloat))
-        self.pos_embed = nn.Parameter(
-            torch.zeros(1, num_patches + 1, dim, dtype=torch.cfloat)
-        )
         with torch.no_grad():
             self.cls_token.real.normal_(0, 0.02)
             self.cls_token.imag.normal_(0, 0.02)
-            self.pos_embed.real.normal_(0, 0.02)
-            self.pos_embed.imag.normal_(0, 0.02)
+
+        self.pos_embed: nn.Parameter | None = None
+        self.pos_enc: SinusoidalPositionalEncoding | None = None
+        rotary: RotaryEmbedding | None = None
+        if pos_encoding == "learned":
+            self.pos_embed = nn.Parameter(
+                torch.zeros(1, num_patches + 1, dim, dtype=torch.cfloat)
+            )
+            with torch.no_grad():
+                self.pos_embed.real.normal_(0, 0.02)
+                self.pos_embed.imag.normal_(0, 0.02)
+        elif pos_encoding == "sinusoidal":
+            self.pos_enc = SinusoidalPositionalEncoding(dim)
+        else:  # rotary
+            rotary = RotaryEmbedding(dim // heads)
 
         self.drop = Dropout(dropout)
         self.blocks = nn.ModuleList(
             [
-                ViTLayer(dim, heads, mlp_dim, dropout, layer_norm_eps, softmax_on)
+                ViTLayer(
+                    dim, heads, mlp_dim, dropout, layer_norm_eps, softmax_on, rotary
+                )
                 for _ in range(depth)
             ]
         )
@@ -140,7 +182,10 @@ class ViT(nn.Module):
         x = x.flatten(2).transpose(1, 2)  # (B, N, dim)
         cls = self.cls_token.expand(b, -1, -1)
         x = torch.cat([cls, x], dim=1)
-        x = x + self.pos_embed
+        if self.pos_embed is not None:
+            x = x + self.pos_embed
+        elif self.pos_enc is not None:
+            x = self.pos_enc(x)
         x = self.drop(x)
         for block in self.blocks:
             x = block(x)

--- a/complextorch/nn/__init__.py
+++ b/complextorch/nn/__init__.py
@@ -46,6 +46,12 @@ from complextorch.nn.modules.casting import (
 )
 from complextorch.nn.modules.phase import PhaseShift, ComplexScaling
 
+from complextorch.nn.modules.position import (
+    RotaryEmbedding,
+    SinusoidalPositionalEncoding,
+    CoPE,
+)
+
 from complextorch.nn.modules.phase_modulation import (
     PhaseDivConv1d,
     PhaseDivConv2d,
@@ -113,6 +119,11 @@ from complextorch.nn.modules.loss import (
     SplitMSE,
 )
 from complextorch.nn.modules.loss import (
+    AnalyticSignalLoss,
+    HolographicReconstructionLoss,
+    phase_smoothness,
+)
+from complextorch.nn.modules.loss import (
     CVQuadError,
     CVFourthPowError,
     CVCauchyError,
@@ -139,6 +150,19 @@ from complextorch.nn.modules.upsampling import Upsample, PolarUpsample
 
 from complextorch.nn.modules.rnn import GRUCell, GRU, LSTMCell, LSTM
 
+from complextorch.nn.modules.unitary_rnn import UnitaryRNN, UnitaryRNNCell
+
+from complextorch.nn.modules.ssm import S4D, DSS, S4DBlock, MambaBlock
+
+from complextorch.nn.modules.kan import CVKANLayer
+
+from complextorch.nn.modules.frontend import (
+    STFT,
+    InverseSTFT,
+    ComplexGaborConv1d,
+    MorletConv1d,
+)
+
 from complextorch.nn.modules.transformer import (
     TransformerEncoderLayer,
     TransformerEncoder,
@@ -152,6 +176,7 @@ from complextorch.nn.modules.attention import (
     MultiheadAttention,
     ScaledDotProductAttention,
 )
+from complextorch.nn.modules.attention.holographic import HolographicAttention
 from complextorch.nn.modules.attention.eca import (
     EfficientChannelAttention1d,
     EfficientChannelAttention2d,
@@ -167,14 +192,20 @@ __all__ = [
     "CCELU",
     "CELU",
     "CGELU",
+    # state-space models
+    "DSS",
     "GRU",
     "LSTM",
+    "S4D",
     "SSIM",
+    "STFT",
     # pooling
     "AdaptiveAvgPool1d",
     "AdaptiveAvgPool2d",
     "AdaptiveAvgPool3d",
     "AdaptiveModReLU",
+    # kan / analytic
+    "AnalyticSignalLoss",
     "AvgPool1d",
     "AvgPool2d",
     "AvgPool3d",
@@ -190,6 +221,7 @@ __all__ = [
     "CVCardiod",
     "CVCauchyError",
     "CVFourthPowError",
+    "CVKANLayer",
     "CVLogCoshError",
     "CVLogError",
     "CVPolarLog",
@@ -208,6 +240,9 @@ __all__ = [
     "CVSplitReLU",
     "CVSplitSigmoid",
     "CVSplitTanh",
+    "CoPE",
+    # recurrence / front-ends
+    "ComplexGaborConv1d",
     "ComplexRatioMask",
     "ComplexScaling",
     "ComplexToConcatenated",
@@ -239,9 +274,12 @@ __all__ = [
     # losses
     "GeneralizedSplitLoss",
     "GroupNorm",
+    "HolographicAttention",
+    "HolographicReconstructionLoss",
     "IFFTBlock",
     # casting / phase
     "InterleavedToComplex",
+    "InverseSTFT",
     "LSTMCell",
     "LayerNorm",
     # linear
@@ -255,10 +293,12 @@ __all__ = [
     "MagMaxPool3d",
     "MagMinMaxNorm",
     "MagSoftMax",
+    "MambaBlock",
     "MaskedChannelAttention1d",
     "MaskedChannelAttention2d",
     "MaskedChannelAttention3d",
     "Mod",
+    "MorletConv1d",
     # attention
     "MultiheadAttention",
     "NaiveBatchNorm1d",
@@ -280,7 +320,11 @@ __all__ = [
     "PrototypeDistance",
     "RMSNorm",
     "RealToComplex",
+    # positional encoding
+    "RotaryEmbedding",
+    "S4DBlock",
     "ScaledDotProductAttention",
+    "SinusoidalPositionalEncoding",
     "SpectralPool1d",
     "SpectralPool2d",
     "SpectralPool3d",
@@ -293,6 +337,8 @@ __all__ = [
     "TransformerEncoder",
     # transformer
     "TransformerEncoderLayer",
+    "UnitaryRNN",
+    "UnitaryRNNCell",
     # upsampling
     "Upsample",
     "gauss",
@@ -300,6 +346,7 @@ __all__ = [
     "init",
     "masked",
     "modReLU",
+    "phase_smoothness",
     "relevance",
     "tReLU",
     "utils",

--- a/complextorch/nn/modules/attention/__init__.py
+++ b/complextorch/nn/modules/attention/__init__.py
@@ -2,6 +2,8 @@ import torch
 import torch.nn as nn
 
 from complextorch import nn as cvnn
+from complextorch.nn.modules.attention.holographic import HolographicAttention
+from complextorch.nn.modules.position import RotaryEmbedding
 
 __all__ = ["MultiheadAttention", "ScaledDotProductAttention"]
 
@@ -82,6 +84,18 @@ class MultiheadAttention(nn.Module):
     Multihead self attention extended to complex-valued tensors.
 
     By default, the :class:`MultiheadAttention` employs :class:`complextorch.nn.CVSoftMax`, which applies the traditional softmax to the real and imaginary parts of the complex-valued tensor separately. Pass :class:`complextorch.nn.PhaseSoftMax` via ``SoftMaxClass`` for the phase-preserving alternative.
+
+    Pass a :class:`complextorch.nn.RotaryEmbedding` via ``rotary`` to inject
+    relative positional information; it is applied to the per-head query and key
+    tensors after projection and must be constructed with ``dim=d_k``. Rotary is
+    intended for **self-attention** (a shared query/key position axis); for
+    cross-attention with differing query/key positions the relative-offset
+    semantics are not meaningful, so prefer an additive encoding there.
+
+    Set ``attention='holographic'`` to use the interference-aware
+    :class:`~complextorch.nn.HolographicAttention` core instead of the default
+    scaled dot-product attention (in which case ``SoftMaxClass`` / ``softmax_on``
+    are unused).
     """
 
     def __init__(
@@ -93,24 +107,37 @@ class MultiheadAttention(nn.Module):
         dropout: float = 0.1,
         SoftMaxClass: nn.Module = cvnn.CVSoftMax,
         softmax_on: str = "complex",
+        rotary: RotaryEmbedding | None = None,
+        attention: str = "scaled_dot_product",
     ) -> None:
         super().__init__()
+        if attention not in ("scaled_dot_product", "holographic"):
+            raise ValueError(
+                "attention must be 'scaled_dot_product' or 'holographic'; "
+                f"got {attention!r}"
+            )
 
         self.d_k = d_k
         self.d_v = d_v
         self.n_heads = n_heads
+        self.rotary = rotary
 
         self.w_q = cvnn.Linear(d_model, n_heads * d_k, bias=False)
         self.w_k = cvnn.Linear(d_model, n_heads * d_k, bias=False)
         self.w_v = cvnn.Linear(d_model, n_heads * d_v, bias=False)
         self.fc = cvnn.Linear(n_heads * d_v, d_model, bias=False)
 
-        self.attention = ScaledDotProductAttention(
-            temperature=d_k**0.5,
-            attn_dropout=dropout,
-            SoftMaxClass=SoftMaxClass,
-            softmax_on=softmax_on,
-        )
+        if attention == "holographic":
+            self.attention = HolographicAttention(
+                temperature=d_k**0.5, attn_dropout=dropout
+            )
+        else:
+            self.attention = ScaledDotProductAttention(
+                temperature=d_k**0.5,
+                attn_dropout=dropout,
+                SoftMaxClass=SoftMaxClass,
+                softmax_on=softmax_on,
+            )
 
         self.dropout = cvnn.Dropout(dropout)
         self.layer_norm = cvnn.LayerNorm(d_model, eps=1e-6)
@@ -136,6 +163,9 @@ class MultiheadAttention(nn.Module):
             k.transpose(1, 2),
             v.transpose(1, 2),
         )
+
+        if self.rotary is not None:
+            q, k = self.rotary.rotate_q_k(q, k)
 
         q = self.attention(q, k, v)
 

--- a/complextorch/nn/modules/attention/holographic.py
+++ b/complextorch/nn/modules/attention/holographic.py
@@ -1,0 +1,101 @@
+r"""
+Holographic (Interference-Aware) Complex Attention
+==================================================
+
+A complex-valued self-attention variant that treats attention as physical wave
+interference rather than a phase-blind correlation. It (i) gates the attention
+logits by the query/key **phase discrepancy** and (ii) performs a **coherent
+superposition** of the values -- rotating each value by its query/key phase
+difference before the weighted sum, so aligned phases add constructively and
+opposed phases partially cancel.
+
+Based on work from the following paper:
+
+    **Holographic Transformers for Complex-Valued Signal Processing: Integrating
+    Phase Interference into Self-Attention.**
+
+        - https://arxiv.org/abs/2509.19331
+
+For a token pair :math:`(i, j)` with complex score
+:math:`s_{ij} = Q_i K_j^H` and phase difference
+:math:`\Delta\phi_{ij} = \angle s_{ij}`:
+
+.. math::
+
+    \text{sim}_{ij} &= \frac{\Re(s_{ij})}{\lVert Q_i\rVert\,\lVert K_j\rVert + \epsilon}, \\
+    W_{ij} &= \frac{\text{sim}_{ij}}{\sqrt{d_k}}\, e^{-\alpha\lvert\Delta\phi_{ij}\rvert}, \qquad
+    a_{ij} = \texttt{SoftMax}_j(W_{ij}), \\
+    H_i &= \sum_j a_{ij}\, V_j\, e^{j\Delta\phi_{ij}}.
+
+The phase-discrepancy weight :math:`\alpha \ge 0` is learnable (kept
+non-negative via :func:`~torch.nn.functional.softplus`).
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["HolographicAttention"]
+
+
+class HolographicAttention(nn.Module):
+    r"""
+    Holographic / Interference-Aware Attention
+    ------------------------------------------
+
+    Drop-in sibling of
+    :class:`~complextorch.nn.ScaledDotProductAttention` with the same
+    ``forward(q, k, v)`` signature; usable directly or selected inside
+    :class:`~complextorch.nn.MultiheadAttention` via ``attention='holographic'``.
+
+    Args:
+        temperature: score temperature, typically :math:`\sqrt{d_k}`.
+        attn_dropout: dropout probability applied to the (real) attention
+            weights.
+        alpha_init: initial value of the phase-discrepancy weight :math:`\alpha`.
+        eps: small constant guarding the magnitude normalisation.
+    """
+
+    def __init__(
+        self,
+        temperature: float,
+        attn_dropout: float = 0.1,
+        alpha_init: float = 1.0,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.temperature = temperature
+        self.eps = eps
+        self.dropout = nn.Dropout(attn_dropout)
+        self.softmax = nn.Softmax(dim=-1)
+        # Stored as a raw parameter; softplus keeps the effective weight >= 0.
+        self.alpha = nn.Parameter(torch.tensor(float(alpha_init)))
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
+        r"""Computes interference-aware attention.
+
+        Args:
+            q (torch.Tensor): complex-valued query tensor ``(..., L_q, d_k)``.
+            k (torch.Tensor): complex-valued key tensor ``(..., L_k, d_k)``.
+            v (torch.Tensor): complex-valued value tensor ``(..., L_k, d_v)``.
+
+        Returns:
+            torch.Tensor: coherently-superposed complex output ``(..., L_q, d_v)``.
+        """
+        # Hermitian inner product -> complex score; its phase is Delta-phi.
+        scores = torch.matmul(q, k.conj().transpose(-2, -1))
+        dphi = scores.angle()
+
+        q_norm = torch.linalg.vector_norm(q, dim=-1).unsqueeze(-1)
+        k_norm = torch.linalg.vector_norm(k, dim=-1).unsqueeze(-2)
+        sim = scores.real / (q_norm * k_norm + self.eps)
+
+        gate = torch.exp(-F.softplus(self.alpha) * dphi.abs())
+        weights = self.softmax(sim / self.temperature * gate)
+        weights = self.dropout(weights)
+
+        # Coherent superposition: rotate each value by its phase offset.
+        coeff = weights * torch.polar(torch.ones_like(dphi), dphi)
+        return torch.matmul(coeff, v)

--- a/complextorch/nn/modules/frontend.py
+++ b/complextorch/nn/modules/frontend.py
@@ -1,0 +1,262 @@
+r"""
+Learnable Complex Time-Frequency Front-Ends
+===========================================
+
+Differentiable signal front-ends that turn a (real or complex) 1-D signal into
+a native complex time-frequency representation, with learnable parameters so the
+front-end can be trained end-to-end with the rest of the network.
+
+- :class:`STFT` / :class:`InverseSTFT` -- short-time Fourier transform with a
+  **learnable analysis/synthesis window**. The inverse uses a window-squared
+  overlap-add normalisation, so ``InverseSTFT(STFT(x)) == x`` (on the covered,
+  non-edge region) for any non-vanishing window **provided the synthesis window
+  matches the analysis window** -- tie them with ``istft.window = stft.window``
+  (the two modules default to identical Hann windows, but learnable windows
+  diverge once trained unless tied).
+- :class:`ComplexGaborConv1d` / :class:`MorletConv1d` -- learnable complex
+  Gabor / Morlet filterbanks (a complex, wavelet-style analogue of SincNet):
+  each filter is a windowed complex exponential with a learnable centre
+  frequency and bandwidth, applied with a complex 1-D convolution.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["STFT", "ComplexGaborConv1d", "InverseSTFT", "MorletConv1d"]
+
+
+class STFT(nn.Module):
+    r"""
+    Learnable Short-Time Fourier Transform
+    --------------------------------------
+
+    Frames the last dimension of ``input`` into overlapping windows, applies a
+    (learnable) window, and FFTs each frame. Works on real or complex input and
+    always returns a **complex** spectrogram of shape
+    ``(..., n_fft, n_frames)`` (frequency x time, two-sided).
+
+    Args:
+        n_fft: frame length / number of frequency bins.
+        hop_length: hop between frames (defaults to ``n_fft // 2``).
+        learnable_window: if ``True`` the window is a learnable parameter
+            (initialised to a Hann window); otherwise it is a fixed buffer.
+    """
+
+    def __init__(
+        self,
+        n_fft: int,
+        hop_length: int | None = None,
+        learnable_window: bool = True,
+    ) -> None:
+        super().__init__()
+        self.n_fft = n_fft
+        self.hop_length = hop_length if hop_length is not None else n_fft // 2
+        win = torch.hann_window(n_fft)
+        if learnable_window:
+            self.window = nn.Parameter(win)
+        else:
+            self.register_buffer("window", win)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Compute the complex STFT.
+
+        Args:
+            input (torch.Tensor): ``(..., T)`` real or complex signal.
+
+        Returns:
+            torch.Tensor: complex ``(..., n_fft, n_frames)`` spectrogram.
+        """
+        frames = input.unfold(-1, self.n_fft, self.hop_length)  # (..., F, n_fft)
+        frames = frames * self.window
+        spec = torch.fft.fft(frames, n=self.n_fft, dim=-1)  # (..., n_frames, n_fft)
+        return spec.transpose(-2, -1)  # (..., n_fft, n_frames)
+
+    def extra_repr(self) -> str:
+        return f"n_fft={self.n_fft}, hop_length={self.hop_length}"
+
+
+class InverseSTFT(nn.Module):
+    r"""
+    Inverse of :class:`STFT` (window-squared overlap-add)
+    -----------------------------------------------------
+
+    Inverts a complex spectrogram of shape ``(..., n_fft, n_frames)`` back to a
+    time-domain signal via IFFT + windowed overlap-add, normalised by the
+    overlap-added squared window. This reconstructs the original signal exactly
+    on every output sample covered by at least one non-zero window tap **as long
+    as the synthesis window equals the analysis window** used by the forward
+    :class:`STFT`.
+
+    .. note::
+
+        :class:`STFT` and :class:`InverseSTFT` own **separate** windows. They
+        default to identical Hann windows, so an untrained pair already inverts
+        exactly; but two *learnable* windows diverge during training. Tie them
+        to keep the reconstruction exact::
+
+            stft = STFT(n_fft); istft = InverseSTFT(n_fft)
+            istft.window = stft.window   # share the (learnable) window
+
+    Args:
+        n_fft: frame length (must match the forward :class:`STFT`).
+        hop_length: hop between frames (defaults to ``n_fft // 2``).
+        learnable_window: see :class:`STFT`.
+        eps: stabiliser for the window-power normalisation.
+    """
+
+    def __init__(
+        self,
+        n_fft: int,
+        hop_length: int | None = None,
+        learnable_window: bool = True,
+        eps: float = 1e-8,
+    ) -> None:
+        super().__init__()
+        self.n_fft = n_fft
+        self.hop_length = hop_length if hop_length is not None else n_fft // 2
+        self.eps = eps
+        win = torch.hann_window(n_fft)
+        if learnable_window:
+            self.window = nn.Parameter(win)
+        else:
+            self.register_buffer("window", win)
+
+    def forward(self, spec: torch.Tensor) -> torch.Tensor:
+        r"""Reconstruct the time-domain signal.
+
+        Args:
+            spec (torch.Tensor): complex ``(..., n_fft, n_frames)`` spectrogram.
+
+        Returns:
+            torch.Tensor: complex ``(..., T)`` signal.
+        """
+        frames = spec.transpose(-2, -1)  # (..., n_frames, n_fft)
+        frames = torch.fft.ifft(frames, n=self.n_fft, dim=-1)
+        frames = frames * self.window  # synthesis window
+
+        n_frames = frames.shape[-2]
+        hop, n_fft = self.hop_length, self.n_fft
+        out_len = (n_frames - 1) * hop + n_fft
+        batch = frames.shape[:-2]
+
+        signal = torch.zeros(*batch, out_len, dtype=frames.dtype, device=frames.device)
+        wsq = torch.zeros(out_len, dtype=self.window.real.dtype, device=frames.device)
+        win_sq = self.window.abs() ** 2
+        for m in range(n_frames):
+            start = m * hop
+            pad_l = torch.zeros(*batch, start, dtype=frames.dtype, device=frames.device)
+            pad_r = torch.zeros(
+                *batch,
+                out_len - start - n_fft,
+                dtype=frames.dtype,
+                device=frames.device,
+            )
+            signal = signal + torch.cat([pad_l, frames[..., m, :], pad_r], dim=-1)
+            wsq = wsq + F.pad(win_sq, (start, out_len - start - n_fft))
+        return signal / (wsq + self.eps)
+
+    def extra_repr(self) -> str:
+        return f"n_fft={self.n_fft}, hop_length={self.hop_length}"
+
+
+class ComplexGaborConv1d(nn.Module):
+    r"""
+    Learnable Complex Gabor Filterbank (1-D)
+    ----------------------------------------
+
+    A 1-D convolution whose kernels are complex Gabor atoms
+
+    .. math::
+
+        g_o(t) = e^{-t^2 / (2\sigma_o^2)}\; e^{j 2\pi f_o t},
+
+    with a learnable centre frequency :math:`f_o` and bandwidth :math:`\sigma_o`
+    per output channel (shared across input channels, SincNet-style). Produces a
+    complex output.
+
+    Args:
+        in_channels: number of input channels.
+        out_channels: number of filters.
+        kernel_size: filter length (samples).
+        stride: convolution stride.
+        padding: convolution padding.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+
+        self.freq = nn.Parameter(torch.linspace(0.05, 0.45, out_channels))
+        self.log_sigma = nn.Parameter(
+            torch.full((out_channels,), math.log(kernel_size / 6.0))
+        )
+        t = torch.arange(kernel_size, dtype=torch.float32) - (kernel_size - 1) / 2.0
+        self.register_buffer("t", t)
+
+    def _env_carrier(self) -> tuple[torch.Tensor, torch.Tensor]:
+        t = self.t.unsqueeze(0)  # (1, K)
+        sigma = torch.exp(self.log_sigma).unsqueeze(1)  # (O, 1)
+        env = torch.exp(-0.5 * (t / sigma) ** 2)  # (O, K)
+        phase = 2 * math.pi * self.freq.unsqueeze(1) * t  # (O, K)
+        carrier = torch.polar(torch.ones_like(phase), phase)  # (O, K) complex
+        return env, carrier
+
+    def _kernels(self) -> torch.Tensor:
+        env, carrier = self._env_carrier()
+        return env * carrier  # (O, K) complex
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Apply the complex filterbank.
+
+        Args:
+            input (torch.Tensor): ``(B, in_channels, T)`` real or complex signal.
+
+        Returns:
+            torch.Tensor: complex ``(B, out_channels, T')`` feature map.
+        """
+        kern = self._kernels()  # (O, K)
+        weight = (
+            kern.unsqueeze(1)
+            .expand(self.out_channels, self.in_channels, self.kernel_size)
+            .contiguous()
+        )
+        if not input.is_complex():
+            input = input.to(torch.cfloat)
+        return F.conv1d(input, weight, stride=self.stride, padding=self.padding)
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_channels={self.in_channels}, out_channels={self.out_channels}, "
+            f"kernel_size={self.kernel_size}"
+        )
+
+
+class MorletConv1d(ComplexGaborConv1d):
+    r"""
+    Learnable Complex Morlet Filterbank (1-D)
+    -----------------------------------------
+
+    Like :class:`ComplexGaborConv1d` but each atom is made **zero-mean** (the
+    Morlet admissibility correction), subtracting the envelope-weighted mean of
+    the carrier so the filter has no DC response.
+    """
+
+    def _kernels(self) -> torch.Tensor:
+        env, carrier = self._env_carrier()
+        base = env * carrier
+        mean = base.sum(-1, keepdim=True) / env.sum(-1, keepdim=True)
+        return base - env * mean

--- a/complextorch/nn/modules/kan.py
+++ b/complextorch/nn/modules/kan.py
@@ -1,0 +1,108 @@
+r"""
+Complex-Valued Kolmogorov-Arnold Networks (CVKAN)
+=================================================
+
+Kolmogorov-Arnold Networks replace the fixed weights of an MLP with **learnable
+univariate basis functions** on the edges. :class:`CVKANLayer` is a complex
+adaptation that places a learnable radial-basis expansion over the **complex
+plane**: each edge response is a sum of Gaussian bumps centred on a grid of
+complex points, combined with complex coefficients, plus a complex linear base
+(residual) term.
+
+For a complex input feature :math:`z` and grid centres
+:math:`c_1,\dots,c_G \in \mathbb{C}`:
+
+.. math::
+
+    \psi_g(z) = \exp\!\Big(-\frac{|z - c_g|^2}{2h^2}\Big), \qquad
+    y_o = \sum_{i} \sum_{g} W_{o,i,g}\, \psi_g(z_i) + (\mathbf{B} z)_o,
+
+with complex coefficients :math:`W` and a complex linear base :math:`\mathbf{B}`.
+The Gaussian acts on the full complex value (both quadratures), so the learned
+edge function is genuinely two-dimensional.
+
+Reference:
+
+    - **CVKAN: Complex-Valued Kolmogorov-Arnold Networks.**
+      https://arxiv.org/abs/2502.02417
+"""
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.linear import Linear
+
+__all__ = ["CVKANLayer"]
+
+
+class CVKANLayer(nn.Module):
+    r"""
+    Complex-Valued KAN Layer
+    ------------------------
+
+    Maps ``in_features`` complex inputs to ``out_features`` complex outputs with
+    a learnable complex-plane radial-basis expansion plus a complex linear base.
+
+    Args:
+        in_features: number of input features.
+        out_features: number of output features.
+        num_grid: grid resolution **per axis**; the basis uses ``num_grid**2``
+            complex centres laid out on a square grid in the complex plane.
+        grid_range: ``(low, high)`` extent of the grid on each axis.
+        learnable_grid: if ``True`` the centre locations are learnable.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        num_grid: int = 8,
+        grid_range: tuple[float, float] = (-1.0, 1.0),
+        learnable_grid: bool = False,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.num_grid = num_grid
+
+        axis = torch.linspace(grid_range[0], grid_range[1], num_grid)
+        re, im = torch.meshgrid(axis, axis, indexing="ij")
+        centers = torch.complex(re.reshape(-1), im.reshape(-1))  # (G,), G=num_grid^2
+        self.num_centers = centers.numel()
+        if learnable_grid:
+            self.centers = nn.Parameter(centers)
+        else:
+            self.register_buffer("centers", centers)
+
+        # RBF bandwidth = grid spacing.
+        self.h = (grid_range[1] - grid_range[0]) / max(num_grid - 1, 1)
+
+        self.spline_weight = nn.Parameter(
+            0.1
+            * torch.randn(
+                out_features, in_features, self.num_centers, dtype=torch.cfloat
+            )
+        )
+        self.base = Linear(in_features, out_features)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Apply the complex KAN edge functions.
+
+        Args:
+            input (torch.Tensor): complex ``(..., in_features)`` tensor.
+
+        Returns:
+            torch.Tensor: complex ``(..., out_features)`` tensor.
+        """
+        diff = input.unsqueeze(-1) - self.centers  # (..., in, G)
+        psi = torch.exp(-(diff.abs() ** 2) / (2 * self.h**2))  # (..., in, G), real
+        spline = torch.einsum(
+            "...ig,oig->...o", psi.to(self.spline_weight.dtype), self.spline_weight
+        )
+        return spline + self.base(input)
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"num_grid={self.num_grid}"
+        )

--- a/complextorch/nn/modules/loss.py
+++ b/complextorch/nn/modules/loss.py
@@ -2,19 +2,24 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from complextorch.signal import hilbert
+
 __all__ = [
     "SSIM",
+    "AnalyticSignalLoss",
     "CVCauchyError",
     "CVFourthPowError",
     "CVLogCoshError",
     "CVLogError",
     "CVQuadError",
     "GeneralizedSplitLoss",
+    "HolographicReconstructionLoss",
     "MSELoss",
     "PerpLossSSIM",
     "SplitL1",
     "SplitMSE",
     "SplitSSIM",
+    "phase_smoothness",
 ]
 
 
@@ -453,3 +458,98 @@ class CVLogError(nn.Module):
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         err = torch.log(x) - torch.log(y)
         return _reduce(err.abs() ** 2, self.reduction)
+
+
+class HolographicReconstructionLoss(nn.Module):
+    r"""
+    Holographic Reconstruction Loss
+    -------------------------------
+
+    Separate real/imaginary reconstruction term used by the holographic
+    transformer's dual-headed decoder as an anti-"phase-collapse" safeguard:
+
+    .. math::
+
+        \mathcal{L}_\text{recon}(\hat{\mathbf{x}}, \mathbf{x})
+            = \lVert \Re(\hat{\mathbf{x}} - \mathbf{x})\rVert_2^2
+            + \lVert \Im(\hat{\mathbf{x}} - \mathbf{x})\rVert_2^2 .
+
+    Forcing the decoder to recover both quadratures prevents phase-blind
+    solutions. See :class:`complextorch.nn.HolographicAttention` and
+    https://arxiv.org/abs/2509.19331.
+
+    Args:
+        reduction: ``'mean'`` (default), ``'sum'``, or ``'none'``.
+    """
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        self.reduction = reduction
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        d = x - y
+        return _reduce(d.real**2 + d.imag**2, self.reduction)
+
+
+class AnalyticSignalLoss(nn.Module):
+    r"""
+    Analytic-Signal Consistency Penalty
+    -----------------------------------
+
+    Penalises how far a complex latent :math:`\mathbf{z}` is from being an
+    **analytic signal** — i.e. how far its imaginary part is from the Hilbert
+    transform of its real part:
+
+    .. math::
+
+        \mathcal{L}(\mathbf{z}) = \text{reduce}\big(\,
+            |\Im(\mathbf{z}) - \mathcal{H}\{\Re(\mathbf{z})\}|^2 \,\big).
+
+    Driving this to zero enforces the deterministic, orthogonal relationship
+    between the real and imaginary channels that defines an analytic signal —
+    the consistency term of the Analytic Neural Network
+    (:class:`complextorch.models.AnalyticNeuralNetwork`,
+    https://arxiv.org/abs/2409.10075). Unlike the comparison losses above, this
+    takes a **single** argument (the latent).
+
+    Args:
+        dim: signal dimension along which the Hilbert transform is taken.
+        reduction: ``'mean'`` (default), ``'sum'``, or ``'none'``.
+    """
+
+    def __init__(self, dim: int = -1, reduction: str = "mean") -> None:
+        super().__init__()
+        self.dim = dim
+        self.reduction = reduction
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        target_imag = hilbert(z.real, dim=self.dim)
+        return _reduce((z.imag - target_imag) ** 2, self.reduction)
+
+
+def phase_smoothness(
+    x: torch.Tensor, dim: int = -1, reduction: str = "mean"
+) -> torch.Tensor:
+    r"""
+    Phase-Smoothness (Total-Variation) Regularizer
+    ----------------------------------------------
+
+    Penalizes erratic phase fluctuations between adjacent positions along
+    ``dim`` using the wrapped phase difference:
+
+    .. math::
+
+        \mathcal{R}(\mathbf{z}) = \text{reduce}\big(\,
+            | \text{wrap}(\angle z_{n+1} - \angle z_n) | \,\big),
+
+    where ``wrap`` maps the difference into :math:`(-\pi, \pi]`. Companion to
+    :class:`complextorch.nn.HolographicAttention` (https://arxiv.org/abs/2509.19331).
+
+    Args:
+        x: complex-valued tensor.
+        dim: dimension along which adjacent phases are compared.
+        reduction: ``'mean'`` (default), ``'sum'``, or ``'none'``.
+    """
+    diff = torch.diff(x.angle(), dim=dim)
+    wrapped = (diff + torch.pi) % (2 * torch.pi) - torch.pi
+    return _reduce(wrapped.abs(), reduction)

--- a/complextorch/nn/modules/manifold.py
+++ b/complextorch/nn/modules/manifold.py
@@ -628,12 +628,15 @@ class wFMConvStrict2d(nn.Module):
     enforced by parameterising :math:`w_{o, i} = \tilde{w}_{o, i}^2 / \sum_k \tilde{w}_{o, k}^2`
     where :math:`\tilde{w}` is the unconstrained learnable tensor.
 
-    For each output position the closed-form wFM on the manifold is applied:
+    For each output position the closed-form wFM on the manifold is applied —
+    the geometric mean of the magnitudes (the Fréchet mean on :math:`\mathbb{R}^+`)
+    and the **circular** mean of the phases (the Fréchet mean on :math:`SO(2)`):
 
     .. math::
 
         |y_o| = \exp\!\Bigl(\sum_i w_{o, i} \log |z_i|\Bigr), \qquad
-        \arg y_o = \sum_i w_{o, i} \arg z_i
+        \arg y_o = \operatorname{atan2}\!\Bigl(\sum_i w_{o, i} \sin \arg z_i,\;
+                                               \sum_i w_{o, i} \cos \arg z_i\Bigr)
 
     where :math:`\{z_i\}` are the complex inputs from the kernel window
     (across all input channels and spatial positions).
@@ -667,6 +670,19 @@ class wFMConvStrict2d(nn.Module):
         and does not transform as ``0 \mapsto 0 \cdot e^{j\psi}`` under input
         rotation. The result is still well-defined; only exact equivariance
         degrades near the boundary.
+
+    .. note::
+        The phase mean is the weighted **circular** (Fréchet) mean on
+        :math:`SO(2)`: the unit phase vectors are averaged and the angle is
+        recovered with :func:`torch.atan2`. This is correct across the
+        :math:`\pm\pi` branch cut and keeps the layer **exactly**
+        U(1)-equivariant for any input phase distribution. The reference
+        ``ComplexConv2Deffangle`` in
+        `RotLieNet <https://github.com/xingyifei2016/RotLieNet>`_ instead takes a
+        plain arithmetic mean of the raw principal-value angles — only accurate
+        away from :math:`\pm\pi`; this implementation uses the
+        geometrically-correct circular mean, matching the paper's Fréchet-mean
+        definition.
 
     Args:
         in_channels: number of complex input channels.
@@ -750,7 +766,12 @@ class wFMConvStrict2d(nn.Module):
         # Convex weights [O, C*kh*kw]; contract with the unfolded windows.
         w = self._convex_weights()
         log_mag_out = torch.einsum("oj,bjl->bol", w, log_mag_unf)
-        phase_out = torch.einsum("oj,bjl->bol", w, phase_unf)
+        # Circular (Fréchet) mean of the phase on SO(2): average the unit phase
+        # vectors and recover the angle via atan2. Correct across the ±π branch
+        # cut and exactly U(1)-equivariant, unlike a raw weighted sum of angles.
+        cos_out = torch.einsum("oj,bjl->bol", w, phase_unf.cos())
+        sin_out = torch.einsum("oj,bjl->bol", w, phase_unf.sin())
+        phase_out = torch.atan2(sin_out, cos_out)
 
         log_mag_out = log_mag_out.view(B, self.out_channels, out_h, out_w)
         phase_out = phase_out.view(B, self.out_channels, out_h, out_w)

--- a/complextorch/nn/modules/position.py
+++ b/complextorch/nn/modules/position.py
@@ -1,0 +1,234 @@
+r"""
+Complex-Valued Positional Encodings
+===================================
+
+Positional information for complex-valued sequence models (e.g.
+:class:`complextorch.nn.MultiheadAttention`,
+:class:`complextorch.nn.TransformerEncoderLayer`). The native
+:class:`complextorch.nn.Transformer` applies **no** positional encoding on its
+own, so one of these modules must be used to make attention position-aware.
+
+Three flavours are provided:
+
+- :class:`RotaryEmbedding` -- **relative** position via Rotary Position
+  Embedding (RoPE). Each complex feature channel :math:`k` of a token at
+  position :math:`n` is multiplied by a unit phasor :math:`e^{j\omega_k n}`.
+  Under the Hermitian attention inner product :math:`q\,k^H` the per-channel
+  contribution becomes :math:`q_k \overline{k_k}\, e^{j\omega_k (m-n)}`, which
+  depends only on the relative offset :math:`m-n`. Apply it to the query and
+  key tensors (see :meth:`RotaryEmbedding.rotate_q_k`).
+- :class:`SinusoidalPositionalEncoding` -- fixed **absolute** encoding; adds a
+  complex sinusoidal phasor bank :math:`e^{j\omega_k n}` to the embeddings.
+- :class:`CoPE` -- a lightweight **learnable** complex positional encoding with
+  per-channel learnable frequency and phase offset (``2 * dim`` parameters).
+
+RoPE is described in:
+
+    **J. Su, et al. RoFormer: Enhanced Transformer with Rotary Position Embedding.**
+
+        - https://arxiv.org/abs/2104.09864
+
+The complex / phase-modulation reading of RoPE (each rotation is literally a
+multiplication by :math:`e^{j\theta}` on a bank of complex oscillators) makes it
+a natural fit for a complex-valued library.
+"""
+
+import torch
+import torch.nn as nn
+
+__all__ = ["CoPE", "RotaryEmbedding", "SinusoidalPositionalEncoding"]
+
+
+def _inv_freq(dim: int, base: float) -> torch.Tensor:
+    """Geometrically-spaced angular frequencies, one per complex channel."""
+    return 1.0 / (base ** (torch.arange(0, dim, dtype=torch.float32) / dim))
+
+
+def _position_angles(inv_freq: torch.Tensor, seq_len: int, offset: int) -> torch.Tensor:
+    """Outer product ``pos x inv_freq`` -> angle tensor of shape ``(L, dim)``."""
+    pos = torch.arange(
+        offset, offset + seq_len, device=inv_freq.device, dtype=inv_freq.dtype
+    )
+    return torch.outer(pos, inv_freq)
+
+
+class RotaryEmbedding(nn.Module):
+    r"""
+    Complex Rotary Position Embedding (RoPE)
+    ----------------------------------------
+
+    Multiplies the complex feature at sequence position :math:`n` by the
+    position-dependent unit phasor :math:`e^{j\omega_k n}`:
+
+    .. math::
+
+        \tilde{x}_{n,k} = x_{n,k}\, e^{j \omega_k n},
+        \qquad \omega_k = \text{base}^{-k/d}.
+
+    Apply it to the query and key tensors *before* the attention dot product.
+    Because the attention score uses the Hermitian inner product
+    :math:`q\,k^H`, the rotation injected at positions :math:`m` (query) and
+    :math:`n` (key) leaves a residual phase :math:`e^{j\omega_k(m-n)}` that
+    encodes the **relative** position.
+
+    The last tensor dimension is treated as the (complex) feature dimension and
+    must equal ``dim``; the second-to-last dimension is the sequence dimension.
+    This matches the per-head attention layout ``(B, n_heads, L, d_k)`` as well
+    as a plain ``(B, L, d)`` embedding layout.
+
+    Args:
+        dim: number of complex feature channels (size of the last dim).
+        base: geometric base for the frequency schedule (RoPE default 10000).
+        learnable: if ``True`` the per-channel frequencies are learnable.
+    """
+
+    def __init__(
+        self, dim: int, base: float = 10000.0, learnable: bool = False
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.learnable = learnable
+        inv_freq = _inv_freq(dim, base)
+        if learnable:
+            self.inv_freq = nn.Parameter(inv_freq)
+        else:
+            self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, input: torch.Tensor, offset: int = 0) -> torch.Tensor:
+        r"""Rotate ``input`` by the RoPE phasors.
+
+        Args:
+            input (torch.Tensor): ``(..., L, dim)`` tensor; the last dim is the
+                complex feature dim and the second-to-last is the sequence dim.
+            offset (int): position of the first token (useful for KV caching).
+
+        Returns:
+            torch.Tensor: rotated complex tensor of the same shape.
+        """
+        if input.shape[-1] != self.dim:
+            raise ValueError(
+                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
+            )
+        angles = _position_angles(self.inv_freq, input.shape[-2], offset)
+        rotor = torch.polar(torch.ones_like(angles), angles)
+        if not input.is_complex():
+            input = input.to(torch.cfloat)
+        return input * rotor
+
+    def rotate_q_k(
+        self, q: torch.Tensor, k: torch.Tensor, offset: int = 0
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE to both the query and key tensors."""
+        return self.forward(q, offset), self.forward(k, offset)
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}, base={self.base}, learnable={self.learnable}"
+
+
+class SinusoidalPositionalEncoding(nn.Module):
+    r"""
+    Complex Sinusoidal Positional Encoding
+    --------------------------------------
+
+    Fixed **absolute** positional encoding that adds a bank of complex
+    sinusoids to the input embeddings:
+
+    .. math::
+
+        \tilde{x}_{n,k} = x_{n,k} + e^{j \omega_k n},
+        \qquad \omega_k = \text{base}^{-k/d}.
+
+    The last tensor dimension is the (complex) feature dimension and must equal
+    ``dim``; the second-to-last dimension is the sequence dimension.
+
+    Args:
+        dim: number of complex feature channels (size of the last dim).
+        base: geometric base for the frequency schedule.
+    """
+
+    def __init__(self, dim: int, base: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.register_buffer("inv_freq", _inv_freq(dim, base), persistent=False)
+
+    def forward(self, input: torch.Tensor, offset: int = 0) -> torch.Tensor:
+        r"""Add the complex sinusoidal encoding to ``input``.
+
+        Args:
+            input (torch.Tensor): ``(..., L, dim)`` complex tensor.
+            offset (int): position of the first token.
+
+        Returns:
+            torch.Tensor: ``input`` plus the positional phasor bank.
+        """
+        if input.shape[-1] != self.dim:
+            raise ValueError(
+                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
+            )
+        angles = _position_angles(self.inv_freq, input.shape[-2], offset)
+        pe = torch.polar(torch.ones_like(angles), angles)
+        if not input.is_complex():
+            input = input.to(torch.cfloat)
+        return input + pe
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}, base={self.base}"
+
+
+class CoPE(nn.Module):
+    r"""
+    Lightweight Learnable Complex Positional Encoding
+    -------------------------------------------------
+
+    Multiplies the complex feature at position :math:`n` by a learnable rotor
+
+    .. math::
+
+        \tilde{x}_{n,k} = x_{n,k}\, e^{j (\omega_k n + \phi_k)},
+
+    where both the per-channel frequency :math:`\omega_k` and phase offset
+    :math:`\phi_k` are learnable (``2 * dim`` parameters total). Unlike
+    :class:`RotaryEmbedding` -- which uses a *fixed* frequency schedule and is
+    designed to be applied to the query/key tensors for *relative* encoding --
+    :class:`CoPE` is a standalone learnable *absolute* encoding applied to the
+    sequence embeddings.
+
+    The frequencies are initialised to the RoPE schedule and the phase offsets
+    to zero, so an untrained :class:`CoPE` behaves like :class:`RotaryEmbedding`.
+
+    Args:
+        dim: number of complex feature channels (size of the last dim).
+        base: geometric base used to initialise the frequencies.
+    """
+
+    def __init__(self, dim: int, base: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.omega = nn.Parameter(_inv_freq(dim, base))
+        self.phi = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, input: torch.Tensor, offset: int = 0) -> torch.Tensor:
+        r"""Rotate ``input`` by the learnable positional rotor.
+
+        Args:
+            input (torch.Tensor): ``(..., L, dim)`` complex tensor.
+            offset (int): position of the first token.
+
+        Returns:
+            torch.Tensor: rotated complex tensor of the same shape.
+        """
+        if input.shape[-1] != self.dim:
+            raise ValueError(
+                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
+            )
+        angles = _position_angles(self.omega, input.shape[-2], offset) + self.phi
+        rotor = torch.polar(torch.ones_like(angles), angles)
+        if not input.is_complex():
+            input = input.to(torch.cfloat)
+        return input * rotor
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}, base={self.base}"

--- a/complextorch/nn/modules/ssm.py
+++ b/complextorch/nn/modules/ssm.py
@@ -1,0 +1,343 @@
+r"""
+Complex Diagonal State-Space Models (S4D / DSS / selective Mamba)
+=================================================================
+
+Linear-time sequence models whose core is a **diagonal complex** state-space
+model (SSM). The complex-diagonal state is exactly what gives structured SSMs
+their strong performance on perceptual / signal modalities, which makes them a
+natural fit for a complex-valued library and for the long 1-D signals this
+package targets.
+
+A single-input single-output diagonal SSM with state :math:`x \in \mathbb{C}^N`
+evolves as
+
+.. math::
+
+    x'(t) = A\, x(t) + B\, u(t), \qquad y(t) = C\, x(t) + D\, u(t),
+
+with diagonal :math:`A \in \mathbb{C}^{N}`. Discretising with step
+:math:`\Delta` (zero-order hold) gives :math:`\bar{A} = e^{\Delta A}`,
+:math:`\bar{B} = (\bar{A}-1)A^{-1}B`, and a causal convolution kernel
+
+.. math::
+
+    \bar{K}_\ell = \sum_{n} C_n\, \bar{A}_n^{\ell}\, \bar{B}_n, \qquad
+    y = u * \bar{K} + D\,u .
+
+Training uses an FFT long-convolution with this kernel; :meth:`SSMBase.recurrence`
+provides the mathematically-equivalent recurrent rollout (used for exact
+inference and verification).
+
+References:
+
+    - **Gu, Goel, Ré. Efficiently Modeling Long Sequences with Structured State
+      Spaces (S4).** https://arxiv.org/abs/2111.00396
+    - **Gu et al. On the Parameterization and Initialization of Diagonal State
+      Space Models (S4D).** https://arxiv.org/abs/2206.11893
+    - **Gupta, Gu, Berant. Diagonal State Spaces (DSS).**
+      https://arxiv.org/abs/2203.14343
+    - **Gu, Dao. Mamba: Linear-Time Sequence Modeling with Selective State
+      Spaces.** https://arxiv.org/abs/2312.00752
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from complextorch.nn.modules.activation.split_type_A import CGELU
+from complextorch.nn.modules.linear import Linear
+from complextorch.nn.modules.rmsnorm import RMSNorm
+
+__all__ = ["DSS", "S4D", "MambaBlock", "S4DBlock"]
+
+
+class SSMBase(nn.Module):
+    r"""
+    Diagonal Complex State-Space Model (base, S4D-style)
+    ----------------------------------------------------
+
+    Operates on complex sequences of shape ``(B, L, H)`` (batch, length,
+    channels). Each of the ``H`` channels owns an independent diagonal SSM with
+    ``state_size`` complex states.
+
+    The diagonal matrix is parameterised so its real part is always negative
+    (stable): :math:`A = -e^{a_r} + j\,a_i`. ``B`` and ``C`` are complex
+    parameters; the per-channel step ``dt`` and skip ``D`` are real.
+
+    Initialisation follows S4D-Lin: :math:`A_n = -\tfrac12 + j\pi n`.
+
+    Args:
+        channels: number of independent channels ``H``.
+        state_size: state dimension ``N`` per channel.
+        dt_min, dt_max: log-uniform range for the initial step sizes.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        state_size: int = 64,
+        dt_min: float = 1e-3,
+        dt_max: float = 1e-1,
+    ) -> None:
+        super().__init__()
+        self.channels = channels
+        self.state_size = state_size
+
+        # A = -exp(log_neg_A_real) + j * A_imag  (real part stays negative).
+        self.log_neg_A_real = nn.Parameter(
+            torch.full((channels, state_size), math.log(0.5))
+        )
+        a_imag = math.pi * torch.arange(state_size, dtype=torch.float32)
+        self.A_imag = nn.Parameter(a_imag.expand(channels, state_size).clone())
+
+        self.B = nn.Parameter(torch.ones(channels, state_size, dtype=torch.cfloat))
+        self.C = nn.Parameter(torch.randn(channels, state_size, dtype=torch.cfloat))
+        self.D = nn.Parameter(torch.ones(channels))
+
+        log_dt = torch.rand(channels) * (
+            math.log(dt_max) - math.log(dt_min)
+        ) + math.log(dt_min)
+        self.log_dt = nn.Parameter(log_dt)
+
+    # -- parameter views -----------------------------------------------------
+
+    def _A(self) -> torch.Tensor:
+        return torch.complex(-torch.exp(self.log_neg_A_real), self.A_imag)
+
+    def _dtA(self) -> torch.Tensor:
+        """Discretisation exponent ``dt * A`` of shape ``(H, N)``."""
+        return torch.exp(self.log_dt).unsqueeze(-1) * self._A()
+
+    def _discretize(self, length: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(A_bar, B_bar)``; zero-order hold (length-independent)."""
+        dtA = self._dtA()
+        A_bar = torch.exp(dtA)
+        B_bar = (A_bar - 1.0) / self._A() * self.B
+        return A_bar, B_bar
+
+    # -- kernel / forward ----------------------------------------------------
+
+    def _kernel(self, length: int) -> torch.Tensor:
+        """Causal convolution kernel ``K`` of shape ``(H, L)``."""
+        _, B_bar = self._discretize(length)
+        dtA = self._dtA()  # log of A_bar
+        powers = torch.arange(length, device=dtA.device, dtype=dtA.real.dtype)
+        vander = torch.exp(dtA.unsqueeze(-1) * powers)  # (H, N, L)
+        return torch.einsum("hn,hnl->hl", self.C * B_bar, vander)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""FFT long-convolution of the input with the SSM kernel.
+
+        Args:
+            input (torch.Tensor): complex ``(B, L, H)`` sequence.
+
+        Returns:
+            torch.Tensor: complex ``(B, L, H)`` sequence.
+        """
+        length = input.shape[1]
+        kernel = self._kernel(length)  # (H, L)
+        nfft = 2 * length
+        kf = torch.fft.fft(kernel, n=nfft, dim=-1)  # (H, nfft)
+        uf = torch.fft.fft(input, n=nfft, dim=1)  # (B, nfft, H)
+        yf = uf * kf.transpose(0, 1).unsqueeze(0)  # (B, nfft, H)
+        y = torch.fft.ifft(yf, dim=1)[:, :length, :]
+        return y + self.D * input
+
+    def recurrence(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Exact recurrent rollout; equals :meth:`forward` up to FFT error.
+
+        Useful for streaming inference and as a reference implementation.
+
+        Args:
+            input (torch.Tensor): complex ``(B, L, H)`` sequence.
+
+        Returns:
+            torch.Tensor: complex ``(B, L, H)`` sequence.
+        """
+        batch, length, _ = input.shape
+        A_bar, B_bar = self._discretize(length)
+        state = torch.zeros(
+            batch,
+            self.channels,
+            self.state_size,
+            dtype=torch.cfloat,
+            device=input.device,
+        )
+        outputs = []
+        for t in range(length):
+            u_t = input[:, t, :]  # (B, H)
+            state = A_bar * state + B_bar * u_t.unsqueeze(-1)
+            y_t = (self.C * state).sum(-1) + self.D * u_t
+            outputs.append(y_t)
+        return torch.stack(outputs, dim=1)
+
+    def extra_repr(self) -> str:
+        return f"channels={self.channels}, state_size={self.state_size}"
+
+
+class S4D(SSMBase):
+    r"""
+    S4D -- Diagonal Complex State-Space Model
+    -----------------------------------------
+
+    Zero-order-hold diagonal SSM (Gu et al., https://arxiv.org/abs/2206.11893).
+    See :class:`SSMBase` for the full description and arguments.
+    """
+
+
+class DSS(SSMBase):
+    r"""
+    DSS -- Diagonal State Space with normalised kernel
+    --------------------------------------------------
+
+    Variant of :class:`S4D` using the Diagonal-State-Space normalisation
+    (Gupta et al., https://arxiv.org/abs/2203.14343): the input matrix is
+    rescaled by :math:`\Delta A / (e^{L \Delta A} - 1)`, which bounds the kernel
+    over the sequence length :math:`L` regardless of the sign of
+    :math:`\Re(A)`. All other behaviour (kernel construction, FFT convolution,
+    recurrence) is inherited unchanged, so :meth:`forward` and
+    :meth:`recurrence` remain mathematically equivalent.
+    """
+
+    def _discretize(self, length: int) -> tuple[torch.Tensor, torch.Tensor]:
+        dtA = self._dtA()
+        A_bar = torch.exp(dtA)
+        B_bar = self.B * dtA / (torch.exp(length * dtA) - 1.0)
+        return A_bar, B_bar
+
+
+class S4DBlock(nn.Module):
+    r"""
+    Residual S4D Block
+    ------------------
+
+    Stackable block: pre-:class:`~complextorch.nn.RMSNorm` -> diagonal SSM ->
+    complex GELU -> :class:`~complextorch.nn.Linear`, with a residual
+    connection. Operates on ``(B, L, H)`` complex sequences.
+
+    Args:
+        channels: number of channels ``H``.
+        state_size: SSM state dimension.
+        variant: ``'s4d'`` (default) or ``'dss'``.
+        layer_norm_eps: epsilon for the RMSNorm.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        state_size: int = 64,
+        variant: str = "s4d",
+        layer_norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        if variant not in ("s4d", "dss"):
+            raise ValueError(f"variant must be 's4d' or 'dss'; got {variant!r}")
+        self.norm = RMSNorm(channels, eps=layer_norm_eps)
+        ssm_cls = S4D if variant == "s4d" else DSS
+        self.ssm = ssm_cls(channels, state_size)
+        self.act = CGELU()
+        self.out = Linear(channels, channels)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        z = self.norm(input)
+        z = self.ssm(z)
+        z = self.out(self.act(z))
+        return input + z
+
+
+class MambaBlock(nn.Module):
+    r"""
+    Selective (Mamba-style) Complex State-Space Block
+    -------------------------------------------------
+
+    Complex adaptation of the Mamba S6 selective SSM
+    (https://arxiv.org/abs/2312.00752): the input matrix ``B``, output matrix
+    ``C`` and step ``dt`` are **input-dependent**, so the model can selectively
+    propagate or forget information. Because the dynamics are time-varying there
+    is no global convolution kernel; the state is advanced with a sequential
+    selective scan (pure-torch; no custom kernel).
+
+    Operates on ``(B, L, channels)`` complex sequences.
+
+    Args:
+        channels: model dimension.
+        state_size: SSM state dimension ``N``.
+        expand: inner-dimension expansion factor.
+        dt_rank: rank of the low-rank ``dt`` projection (defaults to
+            ``max(1, channels // 16)``).
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        state_size: int = 16,
+        expand: int = 2,
+        dt_rank: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.channels = channels
+        self.state_size = state_size
+        self.d_inner = expand * channels
+        self.dt_rank = dt_rank if dt_rank is not None else max(1, channels // 16)
+
+        self.in_proj = Linear(channels, self.d_inner)
+        self.x_proj = Linear(self.d_inner, self.dt_rank + 2 * state_size)
+        self.dt_proj = Linear(self.dt_rank, self.d_inner)
+        self.out_proj = Linear(self.d_inner, channels)
+
+        # Static diagonal A (S4D-Lin init), shared across the scan.
+        self.log_neg_A_real = nn.Parameter(
+            torch.full((self.d_inner, state_size), math.log(0.5))
+        )
+        a_imag = math.pi * torch.arange(state_size, dtype=torch.float32)
+        self.A_imag = nn.Parameter(a_imag.expand(self.d_inner, state_size).clone())
+        self.D = nn.Parameter(torch.ones(self.d_inner))
+
+    def _A(self) -> torch.Tensor:
+        return torch.complex(-torch.exp(self.log_neg_A_real), self.A_imag)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        r"""Selective scan over the sequence.
+
+        Args:
+            input (torch.Tensor): complex ``(B, L, channels)`` sequence.
+
+        Returns:
+            torch.Tensor: complex ``(B, L, channels)`` sequence.
+        """
+        batch, length, _ = input.shape
+        x = self.in_proj(input)  # (B, L, d_inner)
+
+        proj = self.x_proj(x)  # (B, L, dt_rank + 2N)
+        dt_part = proj[..., : self.dt_rank]
+        B_t = proj[..., self.dt_rank : self.dt_rank + self.state_size]  # (B, L, N)
+        C_t = proj[..., self.dt_rank + self.state_size :]  # (B, L, N)
+        # dt is real & positive (selective gate); derive it from the real part.
+        dt = F.softplus(self.dt_proj(dt_part).real)  # (B, L, d_inner)
+
+        A = self._A()  # (d_inner, N)
+        state = torch.zeros(
+            batch,
+            self.d_inner,
+            self.state_size,
+            dtype=torch.cfloat,
+            device=input.device,
+        )
+        outputs = []
+        for t in range(length):
+            dt_t = dt[:, t].unsqueeze(-1)  # (B, d_inner, 1)
+            A_bar = torch.exp(dt_t * A)  # (B, d_inner, N)
+            B_bar = dt_t * B_t[:, t].unsqueeze(1)  # (B, d_inner, N)
+            state = A_bar * state + B_bar * x[:, t].unsqueeze(-1)
+            y_t = (C_t[:, t].unsqueeze(1) * state).sum(-1) + self.D * x[:, t]
+            outputs.append(y_t)
+        y = torch.stack(outputs, dim=1)  # (B, L, d_inner)
+        return self.out_proj(y)
+
+    def extra_repr(self) -> str:
+        return (
+            f"channels={self.channels}, state_size={self.state_size}, "
+            f"d_inner={self.d_inner}, dt_rank={self.dt_rank}"
+        )

--- a/complextorch/nn/modules/unitary_rnn.py
+++ b/complextorch/nn/modules/unitary_rnn.py
@@ -1,0 +1,186 @@
+r"""
+Unitary Complex Recurrent Neural Networks
+=========================================
+
+Complex RNNs whose hidden-to-hidden transition is constrained to be **unitary**
+(norm-preserving). A unitary recurrence has eigenvalues on the unit circle, so
+repeated application neither shrinks nor blows up the hidden state -- the
+classic complex-domain remedy for vanishing/exploding gradients on long
+sequences.
+
+The unitary matrix is produced by the **Cayley transform** of a learnable
+skew-Hermitian generator:
+
+.. math::
+
+    A = M - M^H \;(\text{skew-Hermitian}), \qquad
+    W = (I - A)(I + A)^{-1} \;(\text{unitary}),
+
+for an unconstrained complex matrix :math:`M`. The recurrence then applies a
+:class:`~complextorch.nn.AdaptiveModReLU` nonlinearity:
+
+.. math::
+
+    h_t = \sigma_{\text{modReLU}}(W h_{t-1} + V x_t).
+
+References:
+
+    - **Arjovsky, Shah, Bengio. Unitary Evolution Recurrent Neural Networks.**
+      https://arxiv.org/abs/1511.06464
+    - **Helfrich, Willmott, Ye. Orthogonal RNNs and the Cayley transform
+      (scoRNN).** https://arxiv.org/abs/1707.09520
+"""
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn import init
+from complextorch.nn.modules.activation.split_type_B import AdaptiveModReLU
+from complextorch.nn.modules.dropout import Dropout
+from complextorch.nn.modules.linear import Linear
+
+__all__ = ["UnitaryRNN", "UnitaryRNNCell"]
+
+
+class UnitaryRNNCell(nn.Module):
+    r"""
+    Unitary Complex RNN Cell
+    ------------------------
+
+    One step of :math:`h_t = \sigma_{\text{modReLU}}(W h_{t-1} + V x_t)` with a
+    unitary recurrence matrix :math:`W` (Cayley transform of a learnable
+    skew-Hermitian generator) and a complex input projection :math:`V`.
+
+    Note: the unitary matrix is materialised via a linear solve (an
+    :math:`O(H^3)` op). :class:`UnitaryRNN` computes it once per forward and
+    passes it back in through the ``w`` argument so it is not rebuilt every
+    timestep; call :meth:`unitary_matrix` to fetch it directly.
+
+    Args:
+        input_size: feature size of ``x``.
+        hidden_size: feature size of ``h``.
+        bias: if ``True``, adds a bias to the input projection ``V``.
+    """
+
+    def __init__(self, input_size: int, hidden_size: int, bias: bool = True) -> None:
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+
+        self.V = Linear(input_size, hidden_size, bias=bias)
+        self.M = nn.Parameter(torch.empty(hidden_size, hidden_size, dtype=torch.cfloat))
+        self.register_buffer("eye", torch.eye(hidden_size, dtype=torch.cfloat))
+        self.nonlinearity = AdaptiveModReLU(hidden_size)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        # Semi-unitary init for the skew-Hermitian generator.
+        init.trabelsi_independent_(self.M)
+
+    def unitary_matrix(self) -> torch.Tensor:
+        r"""Materialise the unitary recurrence matrix :math:`W` via the Cayley
+        transform of the skew-Hermitian generator :math:`A = M - M^H`."""
+        A = self.M - self.M.conj().transpose(-2, -1)
+        return torch.linalg.solve(self.eye + A, self.eye - A)
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        hx: torch.Tensor | None = None,
+        w: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if hx is None:
+            hx = torch.zeros(
+                input.shape[0],
+                self.hidden_size,
+                dtype=torch.cfloat,
+                device=input.device,
+            )
+        # Reuse a precomputed unitary matrix when given (the sequence wrapper
+        # materialises it once per forward instead of once per timestep).
+        if w is None:
+            w = self.unitary_matrix()
+        # (W h)_i for row-vector batch h -> h @ W^T.
+        pre = hx @ w.transpose(-2, -1) + self.V(input)
+        return self.nonlinearity(pre)
+
+
+class UnitaryRNN(nn.Module):
+    r"""
+    Multi-Layer Unitary Complex RNN
+    -------------------------------
+
+    Stacks :class:`UnitaryRNNCell` along the time axis. Unidirectional, with an
+    API mirroring the relevant subset of :class:`torch.nn.RNN`
+    (``num_layers``, ``batch_first``, ``dropout``).
+
+    Args:
+        input_size: feature size of ``x``.
+        hidden_size: hidden feature size.
+        num_layers: number of stacked layers.
+        bias: if ``True``, adds biases to the input projections.
+        batch_first: if ``True``, inputs/outputs are ``(B, T, F)`` instead of
+            ``(T, B, F)``.
+        dropout: inter-layer dropout probability (applied between layers when
+            ``num_layers > 1``).
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int = 1,
+        bias: bool = True,
+        batch_first: bool = False,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.batch_first = batch_first
+
+        self.cells = nn.ModuleList(
+            [
+                UnitaryRNNCell(
+                    input_size if layer == 0 else hidden_size, hidden_size, bias=bias
+                )
+                for layer in range(num_layers)
+            ]
+        )
+        self.drop = Dropout(dropout) if dropout > 0 and num_layers > 1 else None
+
+    def forward(
+        self, input: torch.Tensor, hx: torch.Tensor | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.batch_first:
+            input = input.transpose(0, 1)  # -> (T, B, F)
+        seq_len, batch, _ = input.shape
+
+        if hx is None:
+            hx = torch.zeros(
+                self.num_layers,
+                batch,
+                self.hidden_size,
+                dtype=torch.cfloat,
+                device=input.device,
+            )
+
+        outputs = input
+        states: list[torch.Tensor] = []
+        for layer, cell in enumerate(self.cells):
+            h = hx[layer]
+            # Materialise the unitary matrix once per layer, not per timestep.
+            w = cell.unitary_matrix()
+            outs: list[torch.Tensor] = []
+            for t in range(seq_len):
+                h = cell(outputs[t], h, w)
+                outs.append(h)
+            outputs = torch.stack(outs, dim=0)
+            states.append(h)
+            if self.drop is not None and layer < self.num_layers - 1:
+                outputs = self.drop(outputs)
+
+        if self.batch_first:
+            outputs = outputs.transpose(0, 1)
+        return outputs, torch.stack(states, dim=0)

--- a/complextorch/signal.py
+++ b/complextorch/signal.py
@@ -8,11 +8,62 @@ A small set of complex-aware signal helpers that don't fit naturally in
 - :func:`pwelch` — Welch power spectral density (torch port of
   :func:`scipy.signal.welch`). Works on both real and complex inputs and is
   differentiable end-to-end.
+- :func:`analytic_signal` / :func:`hilbert` — analytic signal and Hilbert
+  transform (torch port of :func:`scipy.signal.hilbert`), differentiable
+  end-to-end. Used by the analytic-signal consistency penalty
+  (:class:`complextorch.nn.AnalyticSignalLoss`).
 """
 
 import torch
 
-__all__ = ["pwelch"]
+__all__ = ["analytic_signal", "hilbert", "pwelch"]
+
+
+def analytic_signal(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    r"""
+    Analytic Signal (torch port of :func:`scipy.signal.hilbert`).
+
+    Returns the complex analytic signal :math:`x_a = x + j\,\mathcal{H}\{x\}`,
+    whose imaginary part is the Hilbert transform of ``x``. Computed by zeroing
+    the negative-frequency half of the FFT and doubling the positive half.
+    Differentiable end-to-end.
+
+    Args:
+        x: real-valued signal (the analytic signal is computed over ``dim``).
+        dim: dimension along which to transform.
+
+    Returns:
+        complex analytic signal of the same shape as ``x``.
+    """
+    n = x.shape[dim]
+    xf = torch.fft.fft(x, dim=dim)
+    h = torch.zeros(n, dtype=x.real.dtype, device=x.device)
+    if n % 2 == 0:
+        h[0] = h[n // 2] = 1.0
+        h[1 : n // 2] = 2.0
+    else:
+        h[0] = 1.0
+        h[1 : (n + 1) // 2] = 2.0
+    shape = [1] * x.dim()
+    shape[dim] = n
+    return torch.fft.ifft(xf * h.view(shape), dim=dim)
+
+
+def hilbert(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    r"""
+    Hilbert Transform :math:`\mathcal{H}\{x\}`.
+
+    The imaginary part of the :func:`analytic_signal` — a 90-degree phase shift
+    of every frequency component. Differentiable end-to-end.
+
+    Args:
+        x: real-valued signal.
+        dim: dimension along which to transform.
+
+    Returns:
+        the (real) Hilbert transform of ``x``.
+    """
+    return analytic_signal(x, dim=dim).imag
 
 
 def _window_view(x: torch.Tensor, dim: int, size: int, stride: int = 1) -> torch.Tensor:

--- a/docs/source/concepts/holographic-attention.md
+++ b/docs/source/concepts/holographic-attention.md
@@ -1,0 +1,56 @@
+# Holographic (interference-aware) attention
+
+{class}`complextorch.nn.HolographicAttention` is a drop-in alternative to
+{class}`complextorch.nn.ScaledDotProductAttention` that treats attention as
+**wave interference** rather than a phase-blind correlation. It is motivated by
+signal-processing workloads (PolSAR, wireless channel prediction) where the
+amplitude–phase coupling carries the signal.
+
+It changes two things relative to standard scaled dot-product attention.
+
+**1 · Phase-gated scores.** For a token pair $(i,j)$ with complex score
+$s_{ij} = Q_i K_j^H$ and phase difference $\Delta\phi_{ij} = \angle s_{ij}$, the
+magnitude-correlation similarity is gated by the phase discrepancy:
+
+$$
+\text{sim}_{ij} = \frac{\Re(s_{ij})}{\lVert Q_i\rVert\,\lVert K_j\rVert + \epsilon},
+\qquad
+W_{ij} = \frac{\text{sim}_{ij}}{\sqrt{d_k}}\, e^{-\alpha\lvert\Delta\phi_{ij}\rvert},
+\qquad a_{ij} = \texttt{SoftMax}_j(W_{ij}).
+$$
+
+In-phase interactions are boosted; anti-phase ones are suppressed. The
+discrepancy weight $\alpha \ge 0$ is **learnable**.
+
+**2 · Coherent superposition.** Values are rotated by their phase offset before
+the weighted sum, so aligned phases add constructively:
+
+$$
+H_i = \sum_j a_{ij}\, V_j\, e^{j\Delta\phi_{ij}} .
+$$
+
+```python
+import torch
+import complextorch as ctorch
+
+mha = ctorch.nn.MultiheadAttention(
+    n_heads=4, d_model=32, d_k=8, d_v=8, attention="holographic"
+)
+x = torch.randn(2, 16, 32, dtype=torch.cfloat)
+y = mha(x, x, x)
+print(y.shape, y.dtype)
+```
+
+## Guarding against phase collapse
+
+The companion paper proves a phase-blind estimator has a non-trivial error
+floor, and uses a dual-headed decoder (reconstruction + task) to force the model
+to retain phase. Two helpers support that recipe:
+
+- {class}`complextorch.nn.HolographicReconstructionLoss` — separate real/imag
+  reconstruction term $\lVert\Re(\hat{x}-x)\rVert_2^2 + \lVert\Im(\hat{x}-x)\rVert_2^2$.
+- {func}`complextorch.nn.phase_smoothness` — total-variation penalty on the
+  wrapped phase difference between adjacent positions.
+
+See [arXiv:2509.19331](https://arxiv.org/abs/2509.19331) for the full
+formulation.

--- a/docs/source/concepts/kan.md
+++ b/docs/source/concepts/kan.md
@@ -1,0 +1,39 @@
+# Complex-Valued KANs
+
+Kolmogorov-Arnold Networks (KANs) replace the fixed scalar weights of an MLP
+with **learnable univariate functions** on the edges.
+{class}`complextorch.nn.CVKANLayer` is a complex adaptation that places a
+learnable radial-basis expansion over the **complex plane**, and
+{class}`complextorch.models.CVKAN` stacks those layers into a network.
+
+## The complex-plane RBF edge function
+
+Each edge response is a sum of Gaussian bumps centred on a grid of complex
+points $c_1,\dots,c_G$, combined with complex coefficients, plus a complex
+linear base (residual):
+
+$$
+\psi_g(z) = \exp\!\Big(-\frac{|z - c_g|^2}{2 h^2}\Big), \qquad
+y_o = \sum_{i}\sum_{g} W_{o,i,g}\,\psi_g(z_i) + (\mathbf{B} z)_o .
+$$
+
+The Gaussian acts on the **full** complex value (both quadratures), so the
+learned edge function is genuinely two-dimensional rather than a real function
+applied per part. The grid uses `num_grid**2` centres laid out on a square in
+the complex plane (optionally learnable).
+
+```python
+import torch
+import complextorch as ctorch
+
+# A 2-layer complex KAN: 4 -> 8 -> 3 complex features.
+model = ctorch.models.CVKAN([4, 8, 3], num_grid=8)
+x = torch.randn(16, 4, dtype=torch.cfloat)
+y = model(x)
+print(y.shape, y.dtype)
+
+# A single edge-function layer can fit a complex map such as z -> z**2.
+layer = ctorch.nn.CVKANLayer(1, 1, num_grid=8)
+```
+
+See [CVKAN (arXiv:2502.02417)](https://arxiv.org/abs/2502.02417).

--- a/docs/source/concepts/positional-encoding.md
+++ b/docs/source/concepts/positional-encoding.md
@@ -1,0 +1,55 @@
+# Complex positional encodings
+
+The native {class}`complextorch.nn.Transformer` and
+{class}`complextorch.nn.MultiheadAttention` apply **no** positional encoding on
+their own — attention is permutation-equivariant, so position has to be injected
+explicitly. `complextorch.nn` ships three complex-valued schemes.
+
+| Module | Type | Position | Mechanism |
+| --- | --- | --- | --- |
+| {class}`complextorch.nn.RotaryEmbedding` | relative | rotary (RoPE) | multiply Q/K by $e^{j\omega_k n}$ |
+| {class}`complextorch.nn.SinusoidalPositionalEncoding` | absolute | additive | add $e^{j\omega_k n}$ |
+| {class}`complextorch.nn.CoPE` | absolute | learnable | multiply by $e^{j(\omega_k n + \phi_k)}$ |
+
+## Rotary embeddings (RoPE) are complex by construction
+
+RoPE encodes position by **rotating** each feature channel by an angle
+proportional to its position. Since this library's tensors are already complex,
+a rotation is literally a multiplication by a unit phasor:
+
+$$
+\tilde{x}_{n,k} = x_{n,k}\, e^{j\omega_k n}, \qquad \omega_k = \text{base}^{-k/d}.
+$$
+
+The attention score uses the Hermitian inner product $Q\,K^H$, so the rotation
+applied at query position $m$ and key position $n$ leaves a residual phase that
+depends only on the **relative** offset $m-n$:
+
+$$
+\tilde{q}_{m,k}\,\overline{\tilde{k}_{n,k}}
+   = q_{m,k}\,\overline{k_{n,k}}\; e^{j\omega_k (m-n)} .
+$$
+
+Apply it inside attention via the `rotary` argument (it is applied to the
+per-head query/key tensors after projection, so build it with `dim=d_k`):
+
+```python
+import torch
+import complextorch as ctorch
+
+d_model, n_heads, d_head = 32, 4, 8
+rope = ctorch.nn.RotaryEmbedding(dim=d_head)
+mha = ctorch.nn.MultiheadAttention(n_heads, d_model, d_head, d_head, rotary=rope)
+
+x = torch.randn(2, 16, d_model, dtype=torch.cfloat)   # (batch, length, d_model)
+y = mha(x, x, x)
+print(y.shape, y.dtype)
+```
+
+## Absolute encodings
+
+{class}`complextorch.nn.SinusoidalPositionalEncoding` adds a fixed complex
+sinusoidal phasor bank to the embeddings, and {class}`complextorch.nn.CoPE` is a
+lightweight learnable variant (per-channel learnable frequency **and** phase,
+`2·dim` parameters). The {class}`complextorch.models.ViT` exposes all three via
+its `pos_encoding=` argument (`"learned"`, `"sinusoidal"`, `"rotary"`).

--- a/docs/source/concepts/state-space-models.md
+++ b/docs/source/concepts/state-space-models.md
@@ -1,0 +1,71 @@
+# Complex state-space models (S4D / DSS / Mamba)
+
+Structured state-space models (SSMs) are linear-time sequence models whose core
+is a **diagonal complex** state transition. The complex-diagonal state is
+exactly what gives these models their strength on long perceptual / signal
+sequences, which makes them a natural fit for this library and for the long 1-D
+signals it targets.
+
+All of the layers operate on complex sequences of shape `(B, L, H)` — batch,
+length, channels.
+
+## The diagonal SSM
+
+A per-channel single-input/single-output SSM with complex state
+$x \in \mathbb{C}^N$ evolves as
+
+$$
+x'(t) = A\,x(t) + B\,u(t), \qquad y(t) = C\,x(t) + D\,u(t),
+$$
+
+with **diagonal** $A \in \mathbb{C}^N$. Discretising with a per-channel step
+$\Delta$ (zero-order hold) gives $\bar A = e^{\Delta A}$,
+$\bar B = (\bar A - 1)A^{-1}B$, and a causal convolution kernel
+
+$$
+\bar K_\ell = \sum_n C_n\, \bar A_n^{\ell}\, \bar B_n, \qquad y = u * \bar K + D\,u.
+$$
+
+{class}`complextorch.nn.S4D` materialises this kernel and applies it with an FFT
+long-convolution during training; {meth}`recurrence` runs the mathematically
+equivalent step-by-step recurrence for exact streaming inference. The diagonal
+$A$ is parameterised with a negative real part for stability and initialised to
+the S4D-Lin schedule $A_n = -\tfrac12 + j\pi n$.
+
+{class}`complextorch.nn.DSS` is a sibling using the Diagonal-State-Space kernel
+normalisation, which bounds the kernel over the sequence length regardless of
+the sign of $\Re(A)$. {class}`complextorch.nn.S4DBlock` wraps either variant in
+a residual `RMSNorm → SSM → GELU → Linear` block for stacking.
+
+```python
+import torch
+import complextorch as ctorch
+
+block = ctorch.nn.S4DBlock(channels=16, state_size=64)
+u = torch.randn(2, 128, 16, dtype=torch.cfloat)   # long 1-D signal
+y = block(u)
+print(y.shape, y.dtype)
+
+# FFT convolution and the recurrent rollout agree:
+ssm = ctorch.nn.S4D(channels=16, state_size=64)
+torch.testing.assert_close(ssm(u), ssm.recurrence(u), atol=1e-4, rtol=1e-4)
+```
+
+## Selective (Mamba) variant
+
+{class}`complextorch.nn.MambaBlock` makes the SSM **selective**: $B$, $C$ and
+the step $\Delta$ become input-dependent, so the model can choose what to
+propagate or forget. Because the dynamics are time-varying there is no global
+convolution kernel — the state is advanced with a sequential selective scan
+(pure-torch; no custom kernel).
+
+```python
+mamba = ctorch.nn.MambaBlock(channels=16, state_size=16)
+y = mamba(u)
+print(y.shape, y.dtype)
+```
+
+See S4 ([arXiv:2111.00396](https://arxiv.org/abs/2111.00396)), S4D
+([arXiv:2206.11893](https://arxiv.org/abs/2206.11893)), DSS
+([arXiv:2203.14343](https://arxiv.org/abs/2203.14343)), and Mamba
+([arXiv:2312.00752](https://arxiv.org/abs/2312.00752)).

--- a/docs/source/concepts/steinmetz.md
+++ b/docs/source/concepts/steinmetz.md
@@ -1,0 +1,51 @@
+# Steinmetz & Analytic networks
+
+A different way to process complex data: instead of complex-native layers, use
+**parallel real-valued subnetworks** whose outputs are coupled into a complex
+latent. {class}`complextorch.models.SteinmetzNetwork` implements this multi-view
+approach, and {class}`complextorch.models.AnalyticNeuralNetwork` adds a
+consistency penalty that provably tightens the generalisation-gap bound.
+
+## Steinmetz network
+
+The stacked real/imag features feed two parallel real MLPs whose outputs become
+the real and imaginary parts of the complex output:
+
+$$
+u = f_\Re([\Re z, \Im z]), \quad v = f_\Im([\Re z, \Im z]), \quad \hat z = u + j v.
+$$
+
+```python
+import torch
+import complextorch as ctorch
+
+net = ctorch.models.SteinmetzNetwork(in_features=4, hidden_features=32, out_features=8)
+x = torch.randn(16, 4, dtype=torch.cfloat)
+y = net(x)
+print(y.shape, y.dtype)
+```
+
+## Analytic network: the consistency penalty
+
+The Analytic Neural Network adds the **analytic-signal consistency penalty**
+({class}`complextorch.nn.AnalyticSignalLoss`), which drives the imaginary part of
+the latent towards the Hilbert transform of its real part:
+
+$$
+\mathcal{L}_{\text{analytic}}(\hat z) =
+   \big\| \Im(\hat z) - \mathcal{H}\{\Re(\hat z)\} \big\|^2 .
+$$
+
+Enforcing this orthogonal real/imag relationship is what lowers the
+generalisation bound relative to a generic Steinmetz network.
+
+```python
+net = ctorch.models.AnalyticNeuralNetwork(4, 32, 8)
+out = net(x)
+loss = out.abs().pow(2).mean() + 0.1 * net.consistency_loss(out)  # task + consistency
+```
+
+The Hilbert transform / analytic signal used here is available directly as
+{func}`complextorch.signal.hilbert` / {func}`complextorch.signal.analytic_signal`.
+
+See [Steinmetz Neural Networks (arXiv:2409.10075)](https://arxiv.org/abs/2409.10075).

--- a/docs/source/concepts/time-frequency-frontends.md
+++ b/docs/source/concepts/time-frequency-frontends.md
@@ -1,0 +1,52 @@
+# Learnable time-frequency front-ends
+
+These modules turn a raw 1-D signal (real **or** complex) into a native complex
+time-frequency representation, with learnable parameters so the front-end trains
+end-to-end with the rest of the model. They complement
+{func}`complextorch.signal.pwelch` and the {class}`complextorch.nn.FFTBlock`
+family.
+
+## Learnable STFT
+
+{class}`complextorch.nn.STFT` frames the signal, applies a **learnable window**
+(initialised to Hann), and FFTs each frame, returning a complex spectrogram of
+shape `(..., n_fft, n_frames)`. {class}`complextorch.nn.InverseSTFT` inverts it
+with a window-squared overlap-add, so with matching windows the round-trip is
+exact on every sample covered by a non-zero window tap.
+
+```python
+import torch
+import complextorch as ctorch
+
+stft  = ctorch.nn.STFT(n_fft=64, hop_length=16)
+istft = ctorch.nn.InverseSTFT(n_fft=64, hop_length=16)
+istft.window = stft.window   # tie the windows so the inverse stays exact once trained
+
+x = torch.randn(2, 1024, dtype=torch.cfloat)   # complex baseband signal
+spec = stft(x)                                  # (2, 64, n_frames), complex
+recon = istft(spec)
+print("spectrogram:", spec.shape, spec.dtype)
+print("reconstruction error (interior):",
+      (recon[..., 64:-64] - x[..., 64:-64]).abs().max().item())
+```
+
+## Learnable complex filterbanks (Gabor / Morlet)
+
+{class}`complextorch.nn.ComplexGaborConv1d` is a complex, wavelet-style analogue
+of SincNet: each output filter is a windowed complex exponential
+
+$$
+g_o(t) = e^{-t^2/(2\sigma_o^2)}\, e^{j 2\pi f_o t}
+$$
+
+with a **learnable** centre frequency $f_o$ and bandwidth $\sigma_o$, applied
+with a complex 1-D convolution. {class}`complextorch.nn.MorletConv1d` is the
+zero-mean (admissible) variant — it subtracts the envelope-weighted mean so the
+filter has no DC response.
+
+```python
+gabor = ctorch.nn.ComplexGaborConv1d(in_channels=1, out_channels=32,
+                                     kernel_size=63, padding=31)
+y = gabor(x.unsqueeze(1))   # (2, 32, 1024), complex
+print(y.shape, y.dtype)
+```

--- a/docs/source/concepts/unitary-rnn.md
+++ b/docs/source/concepts/unitary-rnn.md
@@ -1,0 +1,57 @@
+# Unitary complex RNNs
+
+{class}`complextorch.nn.UnitaryRNN` (and its cell
+{class}`complextorch.nn.UnitaryRNNCell`) constrain the hidden-to-hidden
+transition to be **unitary** — a norm-preserving recurrence whose eigenvalues
+lie on the unit circle. Repeated application neither shrinks nor amplifies the
+hidden state, which is the classic complex-domain remedy for vanishing /
+exploding gradients on long sequences. This complements the existing
+{class}`complextorch.nn.GRU` / {class}`complextorch.nn.LSTM` cells.
+
+## The Cayley parameterisation
+
+A unitary matrix is produced by the **Cayley transform** of a learnable
+skew-Hermitian generator. For an unconstrained complex matrix $M$:
+
+$$
+A = M - M^H \quad(\text{skew-Hermitian}), \qquad
+W = (I - A)(I + A)^{-1} \quad(\text{unitary}),
+$$
+
+and the recurrence applies an {class}`complextorch.nn.AdaptiveModReLU`
+nonlinearity:
+
+$$
+h_t = \sigma_{\text{modReLU}}(W h_{t-1} + V x_t).
+$$
+
+The generator is initialised semi-unitarily with
+{func}`complextorch.nn.init.trabelsi_independent_`.
+
+```python
+import torch
+import complextorch as ctorch
+
+cell = ctorch.nn.UnitaryRNNCell(input_size=8, hidden_size=16)
+
+# The recurrence matrix is exactly unitary: W^H W = I, ||W h|| = ||h||.
+W = cell.unitary_matrix()
+h = torch.randn(4, 16, dtype=torch.cfloat)
+print("norm preserved:",
+      torch.allclose((h @ W.T).abs().pow(2).sum(-1), h.abs().pow(2).sum(-1), atol=1e-4))
+
+rnn = ctorch.nn.UnitaryRNN(8, 16, num_layers=2, batch_first=True)
+x = torch.randn(2, 50, 8, dtype=torch.cfloat)
+out, h_n = rnn(x)
+print(out.shape, h_n.shape)
+```
+
+```{note}
+The unitary matrix is rematerialised via a linear solve on every step, so the
+per-step cost is $O(H^3)$ — the price of an exactly-unitary transition. This is
+a reference implementation; for very wide hidden states a parameterisation that
+avoids the per-step solve would be faster.
+```
+
+See uRNN ([arXiv:1511.06464](https://arxiv.org/abs/1511.06464)) and the Cayley /
+scoRNN orthogonal-RNN line ([arXiv:1707.09520](https://arxiv.org/abs/1707.09520)).

--- a/docs/source/examples/getting_started.md
+++ b/docs/source/examples/getting_started.md
@@ -173,11 +173,105 @@ y.abs().pow(2).sum().backward()
 print(f"x.grad shape {tuple(x.grad.shape)}, all finite = {torch.isfinite(x.grad).all().item()}")
 ```
 
+## 7 · Sequence models: positional encoding & state-space layers
+
+Attention is permutation-equivariant, so the native transformer needs an
+explicit positional encoding. {class}`complextorch.nn.RotaryEmbedding` (RoPE)
+plugs straight into {class}`complextorch.nn.MultiheadAttention` — it rotates the
+per-head queries/keys by complex phasors, so build it with `dim=d_k`. See
+[Complex positional encodings](../concepts/positional-encoding.md).
+
+```{code-cell}
+torch.manual_seed(0)
+d_model, n_heads, d_head = 32, 4, 8
+rope = ctorch.nn.RotaryEmbedding(dim=d_head)
+mha = ctorch.nn.MultiheadAttention(n_heads, d_model, d_head, d_head, rotary=rope)
+
+seq = torch.randn(2, 16, d_model, dtype=torch.cfloat)   # (batch, length, d_model)
+attn_out = mha(seq, seq, seq)
+print("attention output:", attn_out.shape, attn_out.dtype)
+```
+
+For long 1-D signals, the diagonal-complex state-space layers
+({class}`complextorch.nn.S4D` / {class}`complextorch.nn.S4DBlock`) run in linear
+time. Their FFT convolution matches an exact recurrent rollout — see
+[Complex state-space models](../concepts/state-space-models.md).
+
+```{code-cell}
+ssm = ctorch.nn.S4D(channels=8, state_size=32)
+u = torch.randn(2, 64, 8, dtype=torch.cfloat)           # (batch, length, channels)
+y_fft = ssm(u)
+y_rec = ssm.recurrence(u)
+print("S4D output:", y_fft.shape, y_fft.dtype)
+print("FFT vs recurrence max abs diff:", (y_fft - y_rec).abs().max().item())
+```
+
+## 8 · Signal front-ends & unitary recurrence
+
+A {class}`complextorch.nn.STFT` is a learnable-window short-time Fourier
+transform that emits a native complex spectrogram;
+{class}`complextorch.nn.InverseSTFT` inverts it. See
+[Learnable time-frequency front-ends](../concepts/time-frequency-frontends.md).
+
+```{code-cell}
+torch.manual_seed(0)
+sig = torch.randn(2, 256, dtype=torch.cfloat)        # complex baseband signal
+stft  = ctorch.nn.STFT(n_fft=32, hop_length=8)
+istft = ctorch.nn.InverseSTFT(n_fft=32, hop_length=8)
+istft.window = stft.window                           # tie windows -> exact inverse
+
+spec  = stft(sig)                                    # (2, 32, n_frames) complex
+recon = istft(spec)
+print("spectrogram:", spec.shape, spec.dtype)
+print("interior reconstruction error:",
+      (recon[..., 32:-32] - sig[..., 32:-32]).abs().max().item())
+```
+
+{class}`complextorch.nn.UnitaryRNN` has a norm-preserving (unitary) recurrence —
+see [Unitary complex RNNs](../concepts/unitary-rnn.md).
+
+```{code-cell}
+cell = ctorch.nn.UnitaryRNNCell(input_size=8, hidden_size=16)
+W = cell.unitary_matrix()
+print("W^H W == I:", torch.allclose(W.conj().T @ W, torch.eye(16, dtype=torch.cfloat), atol=1e-5))
+```
+
+## 9 · Complex KANs & Steinmetz networks
+
+{class}`complextorch.models.CVKAN` is a Kolmogorov-Arnold network whose edge
+functions are learnable complex-plane radial bases — see
+[Complex-Valued KANs](../concepts/kan.md).
+
+```{code-cell}
+kan = ctorch.models.CVKAN([4, 8, 3], num_grid=6)
+out = kan(torch.randn(16, 4, dtype=torch.cfloat))
+print("CVKAN output:", out.shape, out.dtype)
+```
+
+{class}`complextorch.models.AnalyticNeuralNetwork` processes complex data with
+parallel real subnetworks and an analytic-signal consistency penalty (built on
+{func}`complextorch.signal.analytic_signal`) — see
+[Steinmetz & Analytic networks](../concepts/steinmetz.md).
+
+```{code-cell}
+net = ctorch.models.AnalyticNeuralNetwork(4, 16, 32)
+y = net(torch.randn(8, 4, dtype=torch.cfloat))
+print("Analytic-net output:", y.shape, "| consistency penalty:",
+      round(net.consistency_loss(y).item(), 4))
+```
+
 ## Where next?
 
 - Browse the [API reference](../api/complextorch/index) for the full module
   surface (`nn`, `signal`, `transforms`, `datasets`, `models`).
 - Read the [Activations](../concepts/activations.md) deep-dive for Type-A /
   Type-B / fully-complex / ReLU-variant theory.
+- New in 2.1: [positional encodings](../concepts/positional-encoding.md),
+  [holographic attention](../concepts/holographic-attention.md),
+  [state-space models](../concepts/state-space-models.md),
+  [unitary RNNs](../concepts/unitary-rnn.md),
+  [time-frequency front-ends](../concepts/time-frequency-frontends.md),
+  [complex KANs](../concepts/kan.md), and
+  [Steinmetz / analytic networks](../concepts/steinmetz.md).
 - Check the [changelog](../changelog.md) for what landed in the current
   release.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -99,6 +99,13 @@ examples/index
 concepts/activations
 concepts/native-vs-gauss
 concepts/co-domain-symmetry
+concepts/positional-encoding
+concepts/holographic-attention
+concepts/state-space-models
+concepts/unitary-rnn
+concepts/time-frequency-frontends
+concepts/kan
+concepts/steinmetz
 ```
 
 ```{toctree}

--- a/tests/invariants/test_equivariance.py
+++ b/tests/invariants/test_equivariance.py
@@ -74,11 +74,40 @@ def test_wfm_conv_strict_2d_is_u1_equivariant():
     zero cannot be rotated faithfully in ``(log|z|, arg z)`` form.
     """
     layer = wFMConvStrict2d(in_channels=2, out_channels=3, kernel_size=3, padding=0)
-    # Keep phases away from ±π so a small rotation does not wrap the branch cut.
     torch.manual_seed(0)
     x = 0.5 * torch.randn(2, 2, 6, 6, dtype=torch.cfloat) + 1.5
     rotor = torch.polar(torch.tensor(1.0), torch.tensor(0.3))
     torch.testing.assert_close(layer(x * rotor), layer(x) * rotor, atol=1e-4, rtol=1e-4)
+
+
+def test_wfm_conv_strict_2d_equivariant_across_branch_cut():
+    """The circular phase mean stays U(1)-equivariant even when kernel windows
+    straddle the ±π branch cut — a raw arithmetic mean of angles would not."""
+    layer = wFMConvStrict2d(in_channels=2, out_channels=3, kernel_size=3, padding=0)
+    torch.manual_seed(0)
+    # Full-circle phases and a large rotation (~143°) that pushes many samples
+    # across the ±π discontinuity.
+    mag = torch.rand(2, 2, 6, 6) + 0.5
+    ang = torch.rand(2, 2, 6, 6) * (2 * torch.pi) - torch.pi
+    x = torch.polar(mag, ang)
+    rotor = torch.polar(torch.tensor(1.0), torch.tensor(2.5))
+    torch.testing.assert_close(layer(x * rotor), layer(x) * rotor, atol=1e-4, rtol=1e-4)
+
+
+def test_wfm_conv_strict_2d_phase_cancellation_is_finite():
+    """Degenerate circular-mean case: when a window's unit phase vectors cancel
+    (resultant ≈ 0, i.e. ``atan2`` near the origin) the layer's mean phase is
+    ill-defined, but the forward and backward passes must stay finite (no NaN)."""
+    layer = wFMConvStrict2d(in_channels=1, out_channels=1, kernel_size=2, padding=0)
+    with torch.no_grad():
+        layer.weight.fill_(1.0)  # uniform convex weights (1/N each)
+    # Balanced phases 0, π/2, π, -π/2 -> the unit phase vectors sum to ~0.
+    ang = torch.tensor([[[[0.0, torch.pi / 2], [torch.pi, -torch.pi / 2]]]])
+    x = torch.polar(torch.ones(1, 1, 2, 2), ang).requires_grad_(True)
+    y = layer(x)
+    assert torch.isfinite(y).all()
+    y.real.sum().backward()  # phase-dependent loss stresses atan2 at the origin
+    assert torch.isfinite(x.grad).all()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/invariants/test_ssm_kernel.py
+++ b/tests/invariants/test_ssm_kernel.py
@@ -1,0 +1,27 @@
+"""Property test: the SSM FFT convolution equals the recurrent rollout.
+
+The diagonal state-space layers compute their output two ways -- an FFT long
+convolution with the materialised kernel (:meth:`forward`) and a step-by-step
+recurrence (:meth:`recurrence`). They must agree up to floating-point error.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from complextorch.nn.modules.ssm import DSS, S4D
+
+
+@pytest.mark.parametrize("cls", [S4D, DSS])
+@given(seed=st.integers(0, 10_000), length=st.integers(4, 24))
+@settings(max_examples=5, deadline=None)
+def test_ssm_kernel_matches_recurrence(cls, seed, length):
+    torch.manual_seed(seed)
+    model = cls(channels=3, state_size=8)
+    u = torch.randn(2, length, 3, dtype=torch.cfloat)
+    y_fft = model(u)
+    y_rec = model.recurrence(u)
+    torch.testing.assert_close(y_fft, y_rec, atol=1e-4, rtol=1e-4)

--- a/tests/invariants/test_stft_roundtrip.py
+++ b/tests/invariants/test_stft_roundtrip.py
@@ -1,0 +1,32 @@
+"""Property test: InverseSTFT inverts STFT on the covered interior region.
+
+With matching analysis/synthesis windows the window-squared overlap-add
+reconstructs the original signal exactly on every sample covered by a non-zero
+window tap; we compare the interior (trimming one frame from each end).
+"""
+
+from __future__ import annotations
+
+import torch
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from complextorch.nn.modules.frontend import STFT, InverseSTFT
+
+
+@given(seed=st.integers(0, 10_000), n_extra=st.integers(4, 16))
+@settings(max_examples=8, deadline=None)
+def test_stft_roundtrip(seed, n_extra):
+    n_fft, hop = 16, 4
+    torch.manual_seed(seed)
+    length = n_fft + n_extra * hop  # full coverage, out_len == length
+    x = torch.randn(2, length, dtype=torch.cfloat)
+    stft = STFT(n_fft=n_fft, hop_length=hop)
+    istft = InverseSTFT(n_fft=n_fft, hop_length=hop)
+    recon = istft(stft(x))
+    torch.testing.assert_close(
+        recon[..., n_fft : length - n_fft],
+        x[..., n_fft : length - n_fft],
+        atol=1e-4,
+        rtol=1e-4,
+    )

--- a/tests/models/test_kan.py
+++ b/tests/models/test_kan.py
@@ -1,0 +1,29 @@
+"""Tests for the CVKAN model."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from complextorch.models.kan import CVKAN
+
+
+def test_cvkan_forward_shape():
+    model = CVKAN([4, 8, 3], num_grid=5)
+    x = torch.randn(6, 4, dtype=torch.cfloat)
+    out = model(x)
+    assert out.shape == (6, 3)
+    assert out.is_complex()
+
+
+def test_cvkan_grad_flows():
+    model = CVKAN([4, 6, 2], num_grid=4)
+    x = torch.randn(6, 4, dtype=torch.cfloat)
+    model(x).abs().sum().backward()
+    grads = [p.grad for p in model.parameters() if p.requires_grad]
+    assert all(g is not None for g in grads)
+
+
+def test_cvkan_requires_two_sizes():
+    with pytest.raises(ValueError, match="at least two entries"):
+        CVKAN([4])

--- a/tests/models/test_steinmetz.py
+++ b/tests/models/test_steinmetz.py
@@ -1,0 +1,49 @@
+"""Tests for the Steinmetz and Analytic neural networks."""
+
+from __future__ import annotations
+
+import torch
+
+from complextorch.models.steinmetz import AnalyticNeuralNetwork, SteinmetzNetwork
+from complextorch.signal import analytic_signal
+
+
+def test_steinmetz_forward_shape_and_dtype():
+    net = SteinmetzNetwork(in_features=4, hidden_features=8, out_features=3)
+    x = torch.randn(5, 4, dtype=torch.cfloat)
+    out = net(x)
+    assert out.shape == (5, 3)
+    assert out.is_complex()
+
+
+def test_steinmetz_grad_flows():
+    net = SteinmetzNetwork(4, 8, 3, depth=3)
+    x = torch.randn(5, 4, dtype=torch.cfloat)
+    net(x).abs().sum().backward()
+    grads = [p.grad for p in net.parameters()]
+    assert all(g is not None for g in grads)
+
+
+def test_steinmetz_depth_one():
+    # depth=1 -> a single linear layer per branch (no hidden ReLU stack).
+    net = SteinmetzNetwork(4, 8, 2, depth=1)
+    out = net(torch.randn(3, 4, dtype=torch.cfloat))
+    assert out.shape == (3, 2)
+
+
+def test_analytic_network_forward_and_consistency():
+    net = AnalyticNeuralNetwork(4, 8, 16, depth=2)
+    x = torch.randn(5, 4, dtype=torch.cfloat)
+    out = net(x)
+    assert out.shape == (5, 16)
+    pen = net.consistency_loss(out)
+    assert pen.dim() == 0
+    assert torch.isfinite(pen).all()
+
+
+def test_analytic_network_consistency_zero_on_analytic_latent():
+    net = AnalyticNeuralNetwork(4, 8, 64)
+    z = analytic_signal(torch.randn(3, 64))  # genuine analytic signal
+    torch.testing.assert_close(
+        net.consistency_loss(z), torch.zeros(()), atol=1e-10, rtol=0
+    )

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -66,6 +66,50 @@ def test_vit_invalid_image_patch():
         )
 
 
+@pytest.mark.parametrize("pos_encoding", ["learned", "sinusoidal", "rotary"])
+def test_vit_pos_encoding_modes(pos_encoding):
+    vit = ViT(
+        image_size=16,
+        patch_size=4,
+        num_classes=5,
+        dim=16,
+        depth=1,
+        heads=2,
+        mlp_dim=32,
+        pos_encoding=pos_encoding,
+    )
+    x = torch.randn(1, 1, 16, 16, dtype=torch.cfloat)
+    out = vit(x)
+    assert out.shape == (1, 5)
+
+
+def test_vit_invalid_pos_encoding():
+    with pytest.raises(ValueError, match="pos_encoding must be"):
+        ViT(
+            image_size=16,
+            patch_size=4,
+            num_classes=5,
+            dim=16,
+            depth=1,
+            heads=2,
+            mlp_dim=32,
+            pos_encoding="bogus",
+        )
+
+
+def test_vit_invalid_dim_heads():
+    with pytest.raises(ValueError, match="must be divisible by heads"):
+        ViT(
+            image_size=16,
+            patch_size=4,
+            num_classes=5,
+            dim=18,
+            depth=1,
+            heads=4,
+            mlp_dim=32,
+        )
+
+
 # ---------- Presets (smoke: just instantiate; don't run forward on full sizes) ----------
 
 

--- a/tests/nn/modules/attention/test_attention.py
+++ b/tests/nn/modules/attention/test_attention.py
@@ -9,6 +9,7 @@ from complextorch.nn.modules.attention import (
     MultiheadAttention,
     ScaledDotProductAttention,
 )
+from complextorch.nn.modules.position import RotaryEmbedding
 
 
 def test_scaled_dot_product_complex_softmax():
@@ -51,3 +52,28 @@ def test_multihead_attention_cross():
     v = torch.randn(2, 7, 8, dtype=torch.cfloat)
     out = mha(q, k, v)
     assert out.shape == q.shape
+
+
+def test_multihead_attention_with_rotary():
+    mha = MultiheadAttention(
+        n_heads=2, d_model=8, d_k=4, d_v=4, rotary=RotaryEmbedding(4)
+    )
+    q = torch.randn(2, 5, 8, dtype=torch.cfloat)
+    out = mha(q, q, q)
+    assert out.shape == q.shape
+    assert out.is_complex()
+
+
+def test_multihead_attention_holographic():
+    mha = MultiheadAttention(
+        n_heads=2, d_model=8, d_k=4, d_v=4, attention="holographic"
+    )
+    q = torch.randn(2, 5, 8, dtype=torch.cfloat)
+    out = mha(q, q, q)
+    assert out.shape == q.shape
+    assert out.is_complex()
+
+
+def test_multihead_attention_invalid_attention():
+    with pytest.raises(ValueError, match="attention must be"):
+        MultiheadAttention(n_heads=2, d_model=8, d_k=4, d_v=4, attention="bogus")

--- a/tests/nn/modules/attention/test_holographic.py
+++ b/tests/nn/modules/attention/test_holographic.py
@@ -1,0 +1,53 @@
+"""Tests for HolographicAttention (interference-aware complex attention)."""
+
+from __future__ import annotations
+
+import torch
+
+from complextorch.nn.modules.attention.holographic import HolographicAttention
+
+
+def test_holographic_shape_and_dtype():
+    attn = HolographicAttention(temperature=2.0)
+    q = torch.randn(2, 3, 5, 4, dtype=torch.cfloat)
+    k = torch.randn(2, 3, 7, 4, dtype=torch.cfloat)
+    v = torch.randn(2, 3, 7, 4, dtype=torch.cfloat)
+    out = attn(q, k, v)
+    assert out.shape == (2, 3, 5, 4)
+    assert out.is_complex()
+
+
+def test_holographic_grad_flows_into_alpha():
+    attn = HolographicAttention(temperature=2.0, attn_dropout=0.0)
+    q = torch.randn(1, 4, 4, dtype=torch.cfloat)
+    out = attn(q, q, q)
+    (out.real**2 + out.imag**2).sum().backward()
+    assert attn.alpha.grad is not None
+    assert torch.isfinite(attn.alpha.grad).all()
+
+
+def test_holographic_phase_gate_concentrates_on_aligned_value():
+    """As alpha grows, the phase gate concentrates weight on the in-phase key."""
+    d = 4
+    qv = torch.randn(d, dtype=torch.cfloat)
+    q = qv.unsqueeze(0)  # (1, d)
+    theta = torch.tensor(0.9)
+    rotated = qv * torch.polar(torch.ones(()), theta)
+    k = torch.stack([qv, rotated])  # key 0 aligned, key 1 phase-rotated
+    # Distinct values so the output reveals which key won.
+    v = torch.stack(
+        [torch.ones(d, dtype=torch.cfloat), -torch.ones(d, dtype=torch.cfloat)]
+    )
+    v0 = v[0]
+
+    attn = HolographicAttention(temperature=1.0, attn_dropout=0.0)
+    with torch.no_grad():
+        attn.alpha.fill_(-5.0)  # softplus(-5) ~ 0 -> gate ~ 1 (phase-agnostic)
+    out_weak = attn(q, k, v).squeeze(0)
+    with torch.no_grad():
+        attn.alpha.fill_(5.0)  # strong phase gate
+    out_strong = attn(q, k, v).squeeze(0)
+
+    dist_weak = (out_weak - v0).abs().sum()
+    dist_strong = (out_strong - v0).abs().sum()
+    assert dist_strong < dist_weak

--- a/tests/nn/modules/test_frontend.py
+++ b/tests/nn/modules/test_frontend.py
@@ -1,0 +1,122 @@
+"""Tests for learnable complex time-frequency front-ends."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.frontend import (
+    STFT,
+    ComplexGaborConv1d,
+    InverseSTFT,
+    MorletConv1d,
+)
+
+# ---------- STFT / InverseSTFT ----------
+
+
+def test_stft_shape_and_complex_output():
+    stft = STFT(n_fft=16, hop_length=4)
+    x = torch.randn(2, 64, dtype=torch.cfloat)
+    spec = stft(x)
+    assert spec.shape == (2, 16, 13)  # (n_fft, n_frames); (64-16)//4 + 1 = 13
+    assert spec.is_complex()
+
+
+def test_stft_real_input_casts_to_complex():
+    spec = STFT(16)(torch.randn(2, 64))
+    assert spec.is_complex()
+
+
+def test_stft_istft_roundtrip_interior():
+    stft = STFT(n_fft=16, hop_length=4)
+    istft = InverseSTFT(n_fft=16, hop_length=4)  # windows init identically (Hann)
+    x = torch.randn(2, 64, dtype=torch.cfloat)
+    recon = istft(stft(x))
+    assert recon.shape[-1] == 64
+    torch.testing.assert_close(recon[..., 20:44], x[..., 20:44], atol=1e-4, rtol=1e-4)
+
+
+def test_stft_istft_roundtrip_with_tied_trained_window():
+    # Tying the synthesis window to the analysis window keeps the inverse exact
+    # even after the (now shared) learnable window drifts away from Hann.
+    stft = STFT(n_fft=16, hop_length=4)
+    istft = InverseSTFT(n_fft=16, hop_length=4)
+    istft.window = stft.window  # share the learnable window
+    with torch.no_grad():
+        stft.window.add_(0.2 * torch.randn_like(stft.window))
+    x = torch.randn(2, 64, dtype=torch.cfloat)
+    recon = istft(stft(x))
+    torch.testing.assert_close(recon[..., 20:44], x[..., 20:44], atol=1e-4, rtol=1e-4)
+
+
+def test_stft_grad_flows_into_window():
+    stft = STFT(16, hop_length=4)
+    x = torch.randn(2, 64, dtype=torch.cfloat)
+    stft(x).abs().sum().backward()
+    assert stft.window.grad is not None
+
+
+def test_istft_grad_flows_into_window():
+    istft = InverseSTFT(16, hop_length=4)
+    spec = torch.randn(2, 16, 5, dtype=torch.cfloat)
+    istft(spec).abs().sum().backward()
+    assert istft.window.grad is not None
+
+
+def test_stft_fixed_window_is_buffer():
+    stft = STFT(16, learnable_window=False)
+    istft = InverseSTFT(16, learnable_window=False)
+    assert not isinstance(stft.window, nn.Parameter)
+    assert not isinstance(istft.window, nn.Parameter)
+    x = torch.randn(1, 64, dtype=torch.cfloat)
+    assert istft(stft(x)).is_complex()
+
+
+def test_stft_extra_repr():
+    assert "n_fft=16" in STFT(16, hop_length=4).extra_repr()
+    assert "n_fft=16" in InverseSTFT(16, hop_length=4).extra_repr()
+
+
+# ---------- Gabor / Morlet filterbanks ----------
+
+
+def test_gabor_forward_shape_and_complex():
+    conv = ComplexGaborConv1d(2, 8, kernel_size=15, padding=7)
+    x = torch.randn(3, 2, 64, dtype=torch.cfloat)
+    y = conv(x)
+    assert y.shape == (3, 8, 64)
+    assert y.is_complex()
+
+
+def test_gabor_real_input_casts():
+    conv = ComplexGaborConv1d(1, 4, kernel_size=9, padding=4)
+    y = conv(torch.randn(2, 1, 32))
+    assert y.is_complex()
+
+
+def test_gabor_grad_flows_into_params():
+    conv = ComplexGaborConv1d(2, 8, kernel_size=15, padding=7)
+    x = torch.randn(3, 2, 64, dtype=torch.cfloat)
+    conv(x).abs().sum().backward()
+    assert conv.freq.grad is not None
+    assert conv.log_sigma.grad is not None
+
+
+def test_gabor_extra_repr():
+    assert "out_channels=8" in ComplexGaborConv1d(2, 8, 15).extra_repr()
+
+
+def test_morlet_kernels_are_zero_mean():
+    mor = MorletConv1d(1, 4, kernel_size=21)
+    k = mor._kernels()
+    torch.testing.assert_close(
+        k.sum(-1), torch.zeros(4, dtype=torch.cfloat), atol=1e-5, rtol=0
+    )
+
+
+def test_morlet_forward_complex():
+    y = MorletConv1d(1, 4, kernel_size=9, padding=4)(
+        torch.randn(2, 1, 32, dtype=torch.cfloat)
+    )
+    assert y.is_complex()

--- a/tests/nn/modules/test_kan.py
+++ b/tests/nn/modules/test_kan.py
@@ -1,0 +1,64 @@
+"""Tests for the Complex-Valued KAN layer."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.kan import CVKANLayer
+
+
+def test_cvkan_layer_shape_and_dtype():
+    layer = CVKANLayer(4, 3, num_grid=6)
+    x = torch.randn(5, 4, dtype=torch.cfloat)
+    out = layer(x)
+    assert out.shape == (5, 3)
+    assert out.is_complex()
+
+
+def test_cvkan_num_centers_is_grid_squared():
+    layer = CVKANLayer(2, 2, num_grid=7)
+    assert layer.num_centers == 49
+
+
+def test_cvkan_grad_flows():
+    layer = CVKANLayer(4, 3, num_grid=5)
+    x = torch.randn(5, 4, dtype=torch.cfloat)
+    layer(x).abs().sum().backward()
+    assert layer.spline_weight.grad is not None
+    assert torch.isfinite(layer.spline_weight.grad).all()
+
+
+def test_cvkan_learnable_grid():
+    layer = CVKANLayer(3, 2, num_grid=4, learnable_grid=True)
+    assert isinstance(layer.centers, nn.Parameter)
+    x = torch.randn(6, 3, dtype=torch.cfloat)
+    layer(x).abs().sum().backward()
+    assert layer.centers.grad is not None
+
+
+def test_cvkan_fixed_grid_is_buffer():
+    layer = CVKANLayer(3, 2, num_grid=4)
+    assert not isinstance(layer.centers, nn.Parameter)
+
+
+def test_cvkan_can_fit_a_complex_function():
+    """A few optimisation steps reduce the fit error on z -> z**2."""
+    torch.manual_seed(0)
+    layer = CVKANLayer(1, 1, num_grid=8)
+    x = (torch.rand(256, 1) * 1.6 - 0.8) + 1j * (torch.rand(256, 1) * 1.6 - 0.8)
+    y = x**2
+    opt = torch.optim.Adam(layer.parameters(), lr=0.05)
+    init_loss = (layer(x) - y).abs().pow(2).mean().item()
+    for _ in range(100):
+        opt.zero_grad()
+        loss = (layer(x) - y).abs().pow(2).mean()
+        loss.backward()
+        opt.step()
+    assert loss.item() < init_loss * 0.5
+
+
+def test_cvkan_extra_repr():
+    s = CVKANLayer(4, 3, num_grid=6).extra_repr()
+    assert "in_features=4" in s
+    assert "num_grid=6" in s

--- a/tests/nn/modules/test_loss.py
+++ b/tests/nn/modules/test_loss.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from complextorch.nn.modules.loss import (
     SSIM,
+    AnalyticSignalLoss,
     CVCauchyError,
     CVFourthPowError,
     CVLogCoshError,
@@ -15,12 +16,15 @@ from complextorch.nn.modules.loss import (
     CVQuadError,
     GeneralizedPolarLoss,
     GeneralizedSplitLoss,
+    HolographicReconstructionLoss,
     MSELoss,
     PerpLossSSIM,
     SplitL1,
     SplitMSE,
     SplitSSIM,
+    phase_smoothness,
 )
+from complextorch.signal import analytic_signal
 
 # -------- _reduce branches via parameterized losses --------
 
@@ -30,6 +34,7 @@ REDUCTION_LOSSES = [
     CVCauchyError,
     CVLogCoshError,
     MSELoss,
+    HolographicReconstructionLoss,
 ]
 
 
@@ -167,3 +172,72 @@ def test_cvcauchy_with_custom_c():
     y = torch.randn(4, dtype=torch.cfloat)
     out = loss(x, y)
     assert out.dim() == 0
+
+
+# -------- Holographic reconstruction loss --------
+
+
+def test_holographic_reconstruction_matches_abs_sq():
+    x = torch.randn(3, 5, dtype=torch.cfloat)
+    y = torch.randn(3, 5, dtype=torch.cfloat)
+    out = HolographicReconstructionLoss(reduction="sum")(x, y)
+    torch.testing.assert_close(out, ((x - y).abs() ** 2).sum())
+
+
+def test_holographic_reconstruction_zero_on_identity():
+    x = torch.randn(3, 5, dtype=torch.cfloat)
+    out = HolographicReconstructionLoss()(x, x)
+    torch.testing.assert_close(out, torch.zeros(()))
+
+
+# -------- phase_smoothness regularizer --------
+
+
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_phase_smoothness_reduction(reduction):
+    x = torch.randn(2, 6, dtype=torch.cfloat)
+    out = phase_smoothness(x, dim=-1, reduction=reduction)
+    if reduction == "none":
+        assert out.shape == (2, 5)  # one fewer along the diff dim
+    else:
+        assert out.dim() == 0
+
+
+def test_phase_smoothness_zero_on_constant_phase():
+    # Constant phase along the sequence -> zero variation.
+    mag = torch.rand(1, 8) + 0.1
+    x = torch.polar(mag, torch.full((1, 8), 0.4))
+    out = phase_smoothness(x, dim=-1)
+    torch.testing.assert_close(out, torch.zeros(()), atol=1e-6, rtol=0)
+
+
+def test_phase_smoothness_invalid_reduction():
+    x = torch.randn(2, 6, dtype=torch.cfloat)
+    with pytest.raises(ValueError, match="reduction must be"):
+        phase_smoothness(x, reduction="bogus")
+
+
+# -------- AnalyticSignalLoss --------
+
+
+def test_analytic_signal_loss_zero_on_true_analytic_signal():
+    x = torch.randn(2, 64)
+    z = analytic_signal(x)  # imag(z) == hilbert(real(z)) by construction
+    out = AnalyticSignalLoss()(z)
+    torch.testing.assert_close(out, torch.zeros(()), atol=1e-10, rtol=0)
+
+
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_analytic_signal_loss_reduction(reduction):
+    z = torch.randn(2, 16, dtype=torch.cfloat)
+    out = AnalyticSignalLoss(reduction=reduction)(z)
+    if reduction == "none":
+        assert out.shape == z.shape
+    else:
+        assert out.dim() == 0
+
+
+def test_analytic_signal_loss_invalid_reduction():
+    z = torch.randn(2, 16, dtype=torch.cfloat)
+    with pytest.raises(ValueError, match="reduction must be"):
+        AnalyticSignalLoss(reduction="bogus")(z)

--- a/tests/nn/modules/test_position.py
+++ b/tests/nn/modules/test_position.py
@@ -1,0 +1,149 @@
+"""Tests for complex positional encodings (RoPE / sinusoidal / CoPE)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from complextorch.nn.modules.position import (
+    CoPE,
+    RotaryEmbedding,
+    SinusoidalPositionalEncoding,
+)
+
+# ---------- RotaryEmbedding ----------
+
+
+def test_rotary_shape_and_unit_modulus():
+    rope = RotaryEmbedding(dim=8)
+    x = torch.randn(2, 4, 6, 8, dtype=torch.cfloat)
+    out = rope(x)
+    assert out.shape == x.shape
+    assert out.is_complex()
+    # rotation preserves magnitude
+    torch.testing.assert_close(out.abs(), x.abs(), atol=1e-5, rtol=1e-5)
+
+
+def test_rotary_relative_position_property():
+    """<RoPE(q, m), RoPE(k, n)> depends only on the offset (m - n)."""
+    dim, length = 8, 6
+    rope = RotaryEmbedding(dim)
+    q = torch.randn(1, dim, dtype=torch.cfloat)
+    k = torch.randn(1, dim, dtype=torch.cfloat)
+    qs = rope(q.expand(length, dim))  # same feature at every position
+    ks = rope(k.expand(length, dim))
+    scores = qs @ ks.conj().transpose(-2, -1)  # (L, L) Hermitian inner products
+    # Each diagonal corresponds to a fixed (m - n) and must be constant.
+    for offset in range(-(length - 1), length):
+        diag = torch.diagonal(scores, offset=offset)
+        torch.testing.assert_close(diag, diag[0].expand_as(diag), atol=1e-5, rtol=1e-5)
+
+
+def test_rotary_offset_semantics():
+    dim = 4
+    rope = RotaryEmbedding(dim)
+    x = torch.ones(3, dim, dtype=torch.cfloat)
+    out0 = rope(x, offset=0)
+    out2 = rope(x, offset=2)
+    assert not torch.allclose(out0, out2)
+    full = rope(torch.ones(5, dim, dtype=torch.cfloat))
+    torch.testing.assert_close(out2[0], full[2], atol=1e-5, rtol=1e-5)
+
+
+def test_rotary_real_input_auto_casts():
+    out = RotaryEmbedding(4)(torch.randn(3, 4))
+    assert out.is_complex()
+
+
+def test_rotary_dim_mismatch_raises():
+    with pytest.raises(ValueError, match="must equal dim"):
+        RotaryEmbedding(4)(torch.randn(3, 5, dtype=torch.cfloat))
+
+
+def test_rotary_learnable_grad_flows():
+    rope = RotaryEmbedding(4, learnable=True)
+    assert isinstance(rope.inv_freq, nn.Parameter)
+    x = torch.randn(3, 4, dtype=torch.cfloat)
+    # phase-dependent loss so the gradient w.r.t. frequencies is non-trivial
+    rope(x).real.sum().backward()
+    assert rope.inv_freq.grad is not None
+    assert torch.isfinite(rope.inv_freq.grad).all()
+
+
+def test_rotary_rotate_q_k():
+    rope = RotaryEmbedding(4)
+    q = torch.randn(2, 3, 4, dtype=torch.cfloat)
+    k = torch.randn(2, 5, 4, dtype=torch.cfloat)
+    rq, rk = rope.rotate_q_k(q, k)
+    assert rq.shape == q.shape
+    assert rk.shape == k.shape
+
+
+def test_rotary_extra_repr():
+    s = RotaryEmbedding(4, base=100.0, learnable=True).extra_repr()
+    assert "dim=4" in s
+    assert "learnable=True" in s
+
+
+# ---------- SinusoidalPositionalEncoding ----------
+
+
+def test_sinusoidal_shape_and_additive():
+    pe = SinusoidalPositionalEncoding(dim=6)
+    x = torch.randn(2, 5, 6, dtype=torch.cfloat)
+    out = pe(x)
+    assert out.shape == x.shape
+    assert out.is_complex()
+    # difference equals the (input-independent) positional bank
+    delta = out - x
+    delta2 = pe(torch.zeros_like(x))
+    torch.testing.assert_close(delta, delta2, atol=1e-5, rtol=1e-5)
+
+
+def test_sinusoidal_real_input_auto_casts():
+    out = SinusoidalPositionalEncoding(4)(torch.randn(3, 4))
+    assert out.is_complex()
+
+
+def test_sinusoidal_dim_mismatch_raises():
+    with pytest.raises(ValueError, match="must equal dim"):
+        SinusoidalPositionalEncoding(4)(torch.randn(3, 5, dtype=torch.cfloat))
+
+
+def test_sinusoidal_extra_repr():
+    assert "dim=4" in SinusoidalPositionalEncoding(4).extra_repr()
+
+
+# ---------- CoPE ----------
+
+
+def test_cope_shape_and_unit_modulus():
+    cope = CoPE(dim=8)
+    x = torch.randn(2, 5, 8, dtype=torch.cfloat)
+    out = cope(x)
+    assert out.shape == x.shape
+    torch.testing.assert_close(out.abs(), x.abs(), atol=1e-5, rtol=1e-5)
+
+
+def test_cope_grad_flows_into_both_params():
+    cope = CoPE(4)
+    x = torch.randn(3, 4, dtype=torch.cfloat)
+    cope(x).real.sum().backward()
+    assert cope.omega.grad is not None
+    assert cope.phi.grad is not None
+    assert torch.isfinite(cope.omega.grad).all()
+
+
+def test_cope_real_input_auto_casts():
+    out = CoPE(4)(torch.randn(3, 4))
+    assert out.is_complex()
+
+
+def test_cope_dim_mismatch_raises():
+    with pytest.raises(ValueError, match="must equal dim"):
+        CoPE(4)(torch.randn(3, 5, dtype=torch.cfloat))
+
+
+def test_cope_extra_repr():
+    assert "dim=4" in CoPE(4).extra_repr()

--- a/tests/nn/modules/test_ssm.py
+++ b/tests/nn/modules/test_ssm.py
@@ -1,0 +1,87 @@
+"""Tests for complex diagonal state-space models (S4D / DSS / Mamba)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from complextorch.nn.modules.ssm import DSS, S4D, MambaBlock, S4DBlock
+
+
+@pytest.mark.parametrize("cls", [S4D, DSS])
+def test_ssm_forward_shape_and_dtype(cls):
+    m = cls(channels=4, state_size=8)
+    u = torch.randn(2, 12, 4, dtype=torch.cfloat)
+    y = m(u)
+    assert y.shape == u.shape
+    assert y.is_complex()
+
+
+@pytest.mark.parametrize("cls", [S4D, DSS])
+def test_ssm_grad_flows(cls):
+    m = cls(channels=3, state_size=6)
+    u = torch.randn(2, 10, 3, dtype=torch.cfloat)
+    (m(u).abs() ** 2).sum().backward()
+    for p in (m.log_dt, m.C, m.log_neg_A_real, m.D):
+        assert p.grad is not None
+        assert torch.isfinite(p.grad).all()
+
+
+def test_ssm_extra_repr():
+    s = S4D(channels=4, state_size=8).extra_repr()
+    assert "channels=4" in s
+    assert "state_size=8" in s
+
+
+# ---------- S4DBlock ----------
+
+
+@pytest.mark.parametrize("variant", ["s4d", "dss"])
+def test_s4dblock_forward(variant):
+    block = S4DBlock(channels=6, state_size=8, variant=variant)
+    x = torch.randn(2, 9, 6, dtype=torch.cfloat)
+    out = block(x)
+    assert out.shape == x.shape
+    assert out.is_complex()
+
+
+def test_s4dblock_invalid_variant():
+    with pytest.raises(ValueError, match="variant must be"):
+        S4DBlock(channels=6, variant="bogus")
+
+
+# ---------- MambaBlock ----------
+
+
+def test_mamba_forward_shape():
+    block = MambaBlock(channels=8, state_size=4)
+    x = torch.randn(2, 7, 8, dtype=torch.cfloat)
+    out = block(x)
+    assert out.shape == x.shape
+    assert out.is_complex()
+
+
+def test_mamba_explicit_dt_rank_and_grad():
+    block = MambaBlock(channels=8, state_size=4, dt_rank=3)
+    assert block.dt_rank == 3
+    x = torch.randn(2, 6, 8, dtype=torch.cfloat)
+    (block(x).abs() ** 2).sum().backward()
+    assert block.log_neg_A_real.grad is not None
+    assert torch.isfinite(block.log_neg_A_real.grad).all()
+
+
+def test_mamba_is_input_dependent():
+    """A selective SSM's later output reacts to an earlier-timestep change."""
+    block = MambaBlock(channels=8, state_size=4)
+    x = torch.randn(1, 8, 8, dtype=torch.cfloat)
+    x2 = x.clone()
+    x2[:, 0] += 1.0  # perturb only the first timestep
+    y = block(x)
+    y2 = block(x2)
+    assert not torch.allclose(y[:, -1], y2[:, -1])
+
+
+def test_mamba_extra_repr():
+    s = MambaBlock(channels=8, state_size=4).extra_repr()
+    assert "d_inner=16" in s
+    assert "state_size=4" in s

--- a/tests/nn/modules/test_unitary_rnn.py
+++ b/tests/nn/modules/test_unitary_rnn.py
@@ -1,0 +1,68 @@
+"""Tests for unitary complex RNNs."""
+
+from __future__ import annotations
+
+import torch
+
+from complextorch.nn.modules.unitary_rnn import UnitaryRNN, UnitaryRNNCell
+
+
+def test_unitary_matrix_is_unitary():
+    cell = UnitaryRNNCell(4, 6)
+    w = cell.unitary_matrix()
+    identity = torch.eye(6, dtype=torch.cfloat)
+    torch.testing.assert_close(
+        w.conj().transpose(-2, -1) @ w, identity, atol=1e-5, rtol=1e-5
+    )
+
+
+def test_unitary_recurrence_preserves_norm():
+    cell = UnitaryRNNCell(4, 6)
+    w = cell.unitary_matrix()
+    h = torch.randn(3, 6, dtype=torch.cfloat)
+    wh = h @ w.transpose(-2, -1)
+    torch.testing.assert_close(
+        wh.abs().pow(2).sum(-1), h.abs().pow(2).sum(-1), atol=1e-4, rtol=1e-4
+    )
+
+
+def test_unitary_cell_forward_default_state():
+    cell = UnitaryRNNCell(4, 6)
+    x = torch.randn(3, 4, dtype=torch.cfloat)
+    out = cell(x)
+    assert out.shape == (3, 6)
+    assert out.is_complex()
+
+
+def test_unitary_cell_grad_flows_into_generator():
+    cell = UnitaryRNNCell(4, 6)
+    x = torch.randn(3, 4, dtype=torch.cfloat)
+    h0 = torch.randn(3, 6, dtype=torch.cfloat)  # nonzero so W is exercised
+    cell(x, h0).abs().sum().backward()
+    assert cell.M.grad is not None
+    assert torch.isfinite(cell.M.grad).all()
+
+
+def test_unitary_rnn_sequence_shapes():
+    rnn = UnitaryRNN(4, 6, num_layers=2, dropout=0.1)
+    x = torch.randn(5, 3, 4, dtype=torch.cfloat)  # (T, B, F)
+    out, h_n = rnn(x)
+    assert out.shape == (5, 3, 6)
+    assert h_n.shape == (2, 3, 6)
+
+
+def test_unitary_rnn_batch_first_and_given_state():
+    rnn = UnitaryRNN(4, 6, batch_first=True)
+    x = torch.randn(3, 5, 4, dtype=torch.cfloat)  # (B, T, F)
+    h0 = torch.zeros(1, 3, 6, dtype=torch.cfloat)
+    out, h_n = rnn(x, h0)
+    assert out.shape == (3, 5, 6)
+    assert h_n.shape == (1, 3, 6)
+
+
+def test_unitary_rnn_grad_flows():
+    rnn = UnitaryRNN(4, 6, num_layers=1)
+    x = torch.randn(5, 2, 4, dtype=torch.cfloat)
+    out, _ = rnn(x)
+    out.abs().sum().backward()
+    assert rnn.cells[0].M.grad is not None

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from complextorch.signal import pwelch
+from complextorch.signal import analytic_signal, hilbert, pwelch
 
 
 def test_pwelch_real_default_onesided():
@@ -93,4 +93,41 @@ def test_pwelch_differentiable():
     x = torch.randn(256, requires_grad=True)
     _, psd = pwelch(x, window=64)
     psd.sum().backward()
+    assert x.grad is not None
+
+
+# -------- analytic signal / Hilbert transform --------
+
+
+@pytest.mark.parametrize("n", [64, 65])  # even and odd length branches
+def test_analytic_signal_of_integer_cycle_cosine(n):
+    # cos(2*pi*k*t/N) with integer k -> analytic signal is exactly exp(j*2*pi*k*t/N).
+    k = 5
+    t = torch.arange(n, dtype=torch.float64)
+    phase = 2 * torch.pi * k * t / n
+    za = analytic_signal(torch.cos(phase))
+    expected = torch.complex(torch.cos(phase), torch.sin(phase))
+    torch.testing.assert_close(za, expected, atol=1e-9, rtol=1e-9)
+
+
+def test_hilbert_of_cosine_is_sine():
+    n, k = 128, 7
+    t = torch.arange(n, dtype=torch.float64)
+    phase = 2 * torch.pi * k * t / n
+    torch.testing.assert_close(
+        hilbert(torch.cos(phase)), torch.sin(phase), atol=1e-9, rtol=1e-9
+    )
+
+
+def test_analytic_signal_real_part_preserved_and_dim():
+    x = torch.randn(3, 32)
+    za = analytic_signal(x, dim=-1)
+    assert za.shape == x.shape
+    assert za.is_complex()
+    torch.testing.assert_close(za.real, x, atol=1e-5, rtol=1e-5)
+
+
+def test_analytic_signal_differentiable():
+    x = torch.randn(64, requires_grad=True)
+    analytic_signal(x).imag.sum().backward()
     assert x.grad is not None


### PR DESCRIPTION
Single-commit 2.1.0 release on top of the 2.0.1 line (now on `main`). 734 tests / 100% coverage; `ruff check`, `ruff format --check`, and `sphinx -W` all clean.

**Adds:** complex positional encodings (RoPE/sinusoidal/CoPE), holographic (interference-aware) attention, diagonal-complex state-space models (S4D/DSS/S4DBlock/MambaBlock), unitary RNN, learnable STFT/Gabor/Morlet front-ends, complex KAN, and Steinmetz/Analytic networks (+ `analytic_signal`/`hilbert`).

**Also fixes** `wFMConvStrict2d` to use the circular (Fréchet) mean on SO(2) instead of an arithmetic mean of raw angles — correct across the ±π branch cut and exactly U(1)-equivariant (verified by a new branch-cut test).

Supersedes the earlier #13 (which was mistakenly based on the `2.0.1` branch). The 2.0.1 work it depended on is now merged into `main` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)