### PR TITLE
Clean up 2.1.0 architectures and cut 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to `complextorch` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1]
+
+Internal cleanup and performance pass over the 2.1.0 architectures. No public
+API or numerical-behaviour changes — purely simplification, reuse, and reduced
+allocation/recomputation.
+
+### Changed
+
+- `InverseSTFT` overlap-add now accumulates each frame into its own
+  window-sized slice instead of building full-length zero-pads and
+  concatenating per frame — same reconstruction, fewer allocations
+  (O(frames · n_fft) instead of O(frames · output_length)).
+- `ComplexGaborConv1d` / `MorletConv1d` convolve the channel-summed input with
+  the shared filterbank rather than materialising an `in_channels`-replicated
+  weight on every forward — mathematically identical, lower memory.
+- The diagonal state-space layers (`S4D` / `DSS` / `MambaBlock`) share a single
+  diagonal-`A` parameterisation helper, and the S4D kernel no longer rebuilds
+  the discretised `A` / `dt·A` redundantly within a forward.
+- De-duplicated the complex positional-encoding forward paths
+  (`RotaryEmbedding` / `SinusoidalPositionalEncoding` / `CoPE`) onto a shared
+  phasor helper, and dropped an unused field from `models.ViT`.
+
 ## [2.1.0]
 
 A large modern-architecture expansion: positional encodings, interference-aware

--- a/complextorch/__init__.py
+++ b/complextorch/__init__.py
@@ -10,7 +10,7 @@ For more information see: https://pypi.org/project/complextorch or https://githu
 
 __author__ = "Josiah W. Smith"
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 __all__ = ["datasets", "models", "nn", "signal", "transforms"]
 

--- a/complextorch/models/vit.py
+++ b/complextorch/models/vit.py
@@ -139,7 +139,6 @@ class ViT(nn.Module):
         if dim % heads != 0:
             raise ValueError(f"dim ({dim}) must be divisible by heads ({heads})")
         num_patches = (image_size // patch_size) ** 2
-        self.pos_encoding = pos_encoding
         self.patch_embed = Conv2d(
             in_channels, dim, kernel_size=patch_size, stride=patch_size, bias=True
         )

--- a/complextorch/nn/modules/frontend.py
+++ b/complextorch/nn/modules/frontend.py
@@ -145,17 +145,11 @@ class InverseSTFT(nn.Module):
         signal = torch.zeros(*batch, out_len, dtype=frames.dtype, device=frames.device)
         wsq = torch.zeros(out_len, dtype=self.window.real.dtype, device=frames.device)
         win_sq = self.window.abs() ** 2
+        # Overlap-add: each frame contributes only to its own n_fft-wide slice.
         for m in range(n_frames):
-            start = m * hop
-            pad_l = torch.zeros(*batch, start, dtype=frames.dtype, device=frames.device)
-            pad_r = torch.zeros(
-                *batch,
-                out_len - start - n_fft,
-                dtype=frames.dtype,
-                device=frames.device,
-            )
-            signal = signal + torch.cat([pad_l, frames[..., m, :], pad_r], dim=-1)
-            wsq = wsq + F.pad(win_sq, (start, out_len - start - n_fft))
+            sl = slice(m * hop, m * hop + n_fft)
+            signal[..., sl] = signal[..., sl] + frames[..., m, :]
+            wsq[sl] = wsq[sl] + win_sq
         return signal / (wsq + self.eps)
 
     def extra_repr(self) -> str:
@@ -228,15 +222,14 @@ class ComplexGaborConv1d(nn.Module):
         Returns:
             torch.Tensor: complex ``(B, out_channels, T')`` feature map.
         """
-        kern = self._kernels()  # (O, K)
-        weight = (
-            kern.unsqueeze(1)
-            .expand(self.out_channels, self.in_channels, self.kernel_size)
-            .contiguous()
-        )
+        kern = self._kernels().unsqueeze(1)  # (O, 1, K)
         if not input.is_complex():
             input = input.to(torch.cfloat)
-        return F.conv1d(input, weight, stride=self.stride, padding=self.padding)
+        # Each filter is shared across input channels (SincNet-style), so the
+        # convolution with a per-channel-replicated weight equals convolving the
+        # channel-summed input once — same result, no in_channels replication.
+        summed = input.sum(dim=1, keepdim=True)  # (B, 1, T)
+        return F.conv1d(summed, kern, stride=self.stride, padding=self.padding)
 
     def extra_repr(self) -> str:
         return (

--- a/complextorch/nn/modules/position.py
+++ b/complextorch/nn/modules/position.py
@@ -52,6 +52,24 @@ def _position_angles(inv_freq: torch.Tensor, seq_len: int, offset: int) -> torch
     return torch.outer(pos, inv_freq)
 
 
+def _apply_phasor(
+    input: torch.Tensor, angles: torch.Tensor, dim: int, *, add: bool
+) -> torch.Tensor:
+    """Combine ``input`` with the unit phasor bank ``e^{j·angles}``.
+
+    Validates the feature dim, casts a real ``input`` up to complex, then either
+    adds the phasor (absolute encoding) or multiplies by it (rotary encoding).
+    """
+    if input.shape[-1] != dim:
+        raise ValueError(
+            f"last dim of input ({input.shape[-1]}) must equal dim ({dim})"
+        )
+    phasor = torch.polar(torch.ones_like(angles), angles)
+    if not input.is_complex():
+        input = input.to(torch.cfloat)
+    return input + phasor if add else input * phasor
+
+
 class RotaryEmbedding(nn.Module):
     r"""
     Complex Rotary Position Embedding (RoPE)
@@ -106,15 +124,8 @@ class RotaryEmbedding(nn.Module):
         Returns:
             torch.Tensor: rotated complex tensor of the same shape.
         """
-        if input.shape[-1] != self.dim:
-            raise ValueError(
-                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
-            )
         angles = _position_angles(self.inv_freq, input.shape[-2], offset)
-        rotor = torch.polar(torch.ones_like(angles), angles)
-        if not input.is_complex():
-            input = input.to(torch.cfloat)
-        return input * rotor
+        return _apply_phasor(input, angles, self.dim, add=False)
 
     def rotate_q_k(
         self, q: torch.Tensor, k: torch.Tensor, offset: int = 0
@@ -163,15 +174,8 @@ class SinusoidalPositionalEncoding(nn.Module):
         Returns:
             torch.Tensor: ``input`` plus the positional phasor bank.
         """
-        if input.shape[-1] != self.dim:
-            raise ValueError(
-                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
-            )
         angles = _position_angles(self.inv_freq, input.shape[-2], offset)
-        pe = torch.polar(torch.ones_like(angles), angles)
-        if not input.is_complex():
-            input = input.to(torch.cfloat)
-        return input + pe
+        return _apply_phasor(input, angles, self.dim, add=True)
 
     def extra_repr(self) -> str:
         return f"dim={self.dim}, base={self.base}"
@@ -220,15 +224,8 @@ class CoPE(nn.Module):
         Returns:
             torch.Tensor: rotated complex tensor of the same shape.
         """
-        if input.shape[-1] != self.dim:
-            raise ValueError(
-                f"last dim of input ({input.shape[-1]}) must equal dim ({self.dim})"
-            )
         angles = _position_angles(self.omega, input.shape[-2], offset) + self.phi
-        rotor = torch.polar(torch.ones_like(angles), angles)
-        if not input.is_complex():
-            input = input.to(torch.cfloat)
-        return input * rotor
+        return _apply_phasor(input, angles, self.dim, add=False)
 
     def extra_repr(self) -> str:
         return f"dim={self.dim}, base={self.base}"

--- a/complextorch/nn/modules/ssm.py
+++ b/complextorch/nn/modules/ssm.py
@@ -53,6 +53,24 @@ from complextorch.nn.modules.rmsnorm import RMSNorm
 __all__ = ["DSS", "S4D", "MambaBlock", "S4DBlock"]
 
 
+def _init_diagonal_A(rows: int, state_size: int) -> tuple[nn.Parameter, nn.Parameter]:
+    """S4D-Lin diagonal-``A`` init shared by the static-``A`` SSMs.
+
+    Returns the two learnable tensors ``(log_neg_A_real, A_imag)`` parameterising
+    :math:`A = -e^{a_r} + j\\,a_i` with the S4D-Lin imaginary schedule
+    :math:`a_i = \\pi n`. Used by both :class:`SSMBase` and :class:`MambaBlock`.
+    """
+    log_neg_A_real = nn.Parameter(torch.full((rows, state_size), math.log(0.5)))
+    a_imag = math.pi * torch.arange(state_size, dtype=torch.float32)
+    A_imag = nn.Parameter(a_imag.expand(rows, state_size).clone())
+    return log_neg_A_real, A_imag
+
+
+def _diagonal_A(log_neg_A_real: torch.Tensor, A_imag: torch.Tensor) -> torch.Tensor:
+    """Assemble the stable diagonal ``A = -exp(log_neg_A_real) + j * A_imag``."""
+    return torch.complex(-torch.exp(log_neg_A_real), A_imag)
+
+
 class SSMBase(nn.Module):
     r"""
     Diagonal Complex State-Space Model (base, S4D-style)
@@ -86,11 +104,7 @@ class SSMBase(nn.Module):
         self.state_size = state_size
 
         # A = -exp(log_neg_A_real) + j * A_imag  (real part stays negative).
-        self.log_neg_A_real = nn.Parameter(
-            torch.full((channels, state_size), math.log(0.5))
-        )
-        a_imag = math.pi * torch.arange(state_size, dtype=torch.float32)
-        self.A_imag = nn.Parameter(a_imag.expand(channels, state_size).clone())
+        self.log_neg_A_real, self.A_imag = _init_diagonal_A(channels, state_size)
 
         self.B = nn.Parameter(torch.ones(channels, state_size, dtype=torch.cfloat))
         self.C = nn.Parameter(torch.randn(channels, state_size, dtype=torch.cfloat))
@@ -104,25 +118,28 @@ class SSMBase(nn.Module):
     # -- parameter views -----------------------------------------------------
 
     def _A(self) -> torch.Tensor:
-        return torch.complex(-torch.exp(self.log_neg_A_real), self.A_imag)
+        return _diagonal_A(self.log_neg_A_real, self.A_imag)
 
-    def _dtA(self) -> torch.Tensor:
-        """Discretisation exponent ``dt * A`` of shape ``(H, N)``."""
-        return torch.exp(self.log_dt).unsqueeze(-1) * self._A()
+    def _discretize(
+        self, length: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return ``(A_bar, B_bar, dtA)``; zero-order hold.
 
-    def _discretize(self, length: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return ``(A_bar, B_bar)``; zero-order hold (length-independent)."""
-        dtA = self._dtA()
+        ``length`` is unused here (the S4D kernel is length-independent); it is
+        the seam the :class:`DSS` override uses to normalise over the sequence.
+        ``dtA = log(A_bar)`` is returned so :meth:`_kernel` need not rebuild it.
+        """
+        A = self._A()
+        dtA = torch.exp(self.log_dt).unsqueeze(-1) * A
         A_bar = torch.exp(dtA)
-        B_bar = (A_bar - 1.0) / self._A() * self.B
-        return A_bar, B_bar
+        B_bar = (A_bar - 1.0) / A * self.B
+        return A_bar, B_bar, dtA
 
     # -- kernel / forward ----------------------------------------------------
 
     def _kernel(self, length: int) -> torch.Tensor:
         """Causal convolution kernel ``K`` of shape ``(H, L)``."""
-        _, B_bar = self._discretize(length)
-        dtA = self._dtA()  # log of A_bar
+        _, B_bar, dtA = self._discretize(length)  # dtA is log of A_bar
         powers = torch.arange(length, device=dtA.device, dtype=dtA.real.dtype)
         vander = torch.exp(dtA.unsqueeze(-1) * powers)  # (H, N, L)
         return torch.einsum("hn,hnl->hl", self.C * B_bar, vander)
@@ -157,7 +174,7 @@ class SSMBase(nn.Module):
             torch.Tensor: complex ``(B, L, H)`` sequence.
         """
         batch, length, _ = input.shape
-        A_bar, B_bar = self._discretize(length)
+        A_bar, B_bar, _ = self._discretize(length)
         state = torch.zeros(
             batch,
             self.channels,
@@ -201,11 +218,13 @@ class DSS(SSMBase):
     :meth:`recurrence` remain mathematically equivalent.
     """
 
-    def _discretize(self, length: int) -> tuple[torch.Tensor, torch.Tensor]:
-        dtA = self._dtA()
+    def _discretize(
+        self, length: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        dtA = torch.exp(self.log_dt).unsqueeze(-1) * self._A()
         A_bar = torch.exp(dtA)
         B_bar = self.B * dtA / (torch.exp(length * dtA) - 1.0)
-        return A_bar, B_bar
+        return A_bar, B_bar, dtA
 
 
 class S4DBlock(nn.Module):
@@ -288,15 +307,11 @@ class MambaBlock(nn.Module):
         self.out_proj = Linear(self.d_inner, channels)
 
         # Static diagonal A (S4D-Lin init), shared across the scan.
-        self.log_neg_A_real = nn.Parameter(
-            torch.full((self.d_inner, state_size), math.log(0.5))
-        )
-        a_imag = math.pi * torch.arange(state_size, dtype=torch.float32)
-        self.A_imag = nn.Parameter(a_imag.expand(self.d_inner, state_size).clone())
+        self.log_neg_A_real, self.A_imag = _init_diagonal_A(self.d_inner, state_size)
         self.D = nn.Parameter(torch.ones(self.d_inner))
 
     def _A(self) -> torch.Tensor:
-        return torch.complex(-torch.exp(self.log_neg_A_real), self.A_imag)
+        return _diagonal_A(self.log_neg_A_real, self.A_imag)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         r"""Selective scan over the sequence.


### PR DESCRIPTION
Patch release **2.1.1**: an internal simplification/efficiency pass over the
2.1.0 modern-architecture modules. No public API or numerical-behaviour change.

## Changed
- **`InverseSTFT`** — overlap-add now accumulates each frame into its own
  window-sized slice instead of building full-length zero-pads + concatenating
  per frame. Fewer allocations, O(frames·n_fft) instead of O(frames·out_len);
  reconstruction is identical (verified by the roundtrip + grad tests).
- **`ComplexGaborConv1d` / `MorletConv1d`** — convolve the channel-summed input
  with the shared filterbank instead of materialising an `in_channels`-replicated
  weight every forward. Mathematically identical, lower memory.
- **`S4D` / `DSS` / `MambaBlock`** — share one diagonal-`A` parameterisation
  helper; the S4D kernel no longer rebuilds the discretised `A` / `dt·A`
  redundantly within a forward.
- **`position.py`** — `RotaryEmbedding` / `SinusoidalPositionalEncoding` / `CoPE`
  forwards folded onto a shared phasor helper; removed an unused field from
  `models.ViT`.

## Release
- `__version__` → `2.1.1`, `CHANGELOG.md` entry added.

## Verification (local, mirrors CI)
- `pytest --cov-fail-under=100` → 734 passed, 100% coverage
- `ruff check` + `ruff format --check` → clean
- `sphinx-build -W` → build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)